### PR TITLE
Separate cards on Lend page

### DIFF
--- a/src/components/Tabs/Tabs.module.less
+++ b/src/components/Tabs/Tabs.module.less
@@ -58,7 +58,7 @@
 
 .tabActive {
   border-bottom-color: transparent;
-  background: var(--bg-primary);
+  background: transparent;
 
   &,
   &:hover {

--- a/src/components/inputs/Inputs.module.less
+++ b/src/components/inputs/Inputs.module.less
@@ -25,6 +25,11 @@ body .input {
     color: var(--content-secondary);
   }
 
+  &:disabled {
+    background: var(--bg-action);
+    color: var(--content-secondary);
+  }
+
   @media (max-width: 640px) {
     height: 32px;
   }

--- a/src/pages/LendPage/components/ActivityTable/ActivityTable.module.less
+++ b/src/pages/LendPage/components/ActivityTable/ActivityTable.module.less
@@ -1,4 +1,8 @@
 .tableRoot :global {
+  .ant-table-thead > tr > th {
+    background: var(--bg-primary-deep) !important;
+  }
+
   .ant-table-tbody > tr > td,
   .ant-table-thead > tr > th {
     width: 150px;

--- a/src/pages/LendPage/components/LendCard/LendCard.module.less
+++ b/src/pages/LendPage/components/LendCard/LendCard.module.less
@@ -1,10 +1,8 @@
 .card {
-  border-bottom: var(--border-less-primary);
+  background: var(--bg-primary-deep);
+  border: var(--border-less-primary);
   cursor: pointer;
   width: 100%;
-}
-.card.active {
-  border: 0;
 }
 
 .row {
@@ -19,7 +17,7 @@
   justify-content: space-between;
   align-items: center;
   position: relative;
-  padding: 12px 24px;
+  padding: 24px;
   width: 100%;
 
   @media (max-width: 960px) {

--- a/src/pages/LendPage/components/LendCard/LendCard.module.less
+++ b/src/pages/LendPage/components/LendCard/LendCard.module.less
@@ -1,6 +1,8 @@
 .card {
   background: var(--bg-primary-deep);
   border: var(--border-less-primary);
+  border-left: 0;
+  border-right: 0;
   cursor: pointer;
   width: 100%;
 }

--- a/src/pages/LendPage/components/LendCard/LendCard.tsx
+++ b/src/pages/LendPage/components/LendCard/LendCard.tsx
@@ -29,7 +29,7 @@ const LendCard: FC<LendCardProps> = ({ isCardOpen, onCardClick, market, isOrderB
   }, [isCardOpen])
 
   return (
-    <div ref={cardRef} className={classNames(styles.card, { [styles.active]: isCardOpen })}>
+    <div ref={cardRef} className={styles.card}>
       <div
         className={classNames(styles.cardBody, { [styles.active]: isCardOpen })}
         onClick={onCardClick}

--- a/src/pages/LendPage/components/LendPageContent/LendPageContent.module.less
+++ b/src/pages/LendPage/components/LendPageContent/LendPageContent.module.less
@@ -17,3 +17,9 @@
 .emptyListTitle {
   font: var(--body-text-md);
 }
+
+.marketsList {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}

--- a/src/pages/LendPage/components/LendPageContent/components.tsx
+++ b/src/pages/LendPage/components/LendPageContent/components.tsx
@@ -29,7 +29,7 @@ export const MarketsList: FC<MarketsListProps> = ({
   const isMobile = width < TABLET_WIDTH
 
   return (
-    <>
+    <div className={styles.marketsList}>
       {markets.map((market: MarketPreview) => {
         const { collectionName, marketPubkey } = market
 
@@ -46,6 +46,6 @@ export const MarketsList: FC<MarketsListProps> = ({
           />
         )
       })}
-    </>
+    </div>
   )
 }

--- a/src/pages/LendPage/components/OrderBook/OrderBook.module.less
+++ b/src/pages/LendPage/components/OrderBook/OrderBook.module.less
@@ -15,8 +15,6 @@
 }
 
 .orderBook {
-  background: var(--bg-primary);
-
   display: flex;
   flex-direction: column;
   margin-right: 24px;


### PR DESCRIPTION
## Description

Separate cards on Lend page
Change background to "transparent" on tabs
Change thead background on "ActivityTable"
Change background on OrderBook

## Screenshots

<img width="1464" alt="image" src="https://github.com/frakt-solana/banx-ui/assets/60342317/a3df6407-30c0-4871-a048-125d7f5f5a48">

## Issue link

https://linear.app/banx-gg/issue/BAN-1175/fe-banx-separate-cards-on-lend-page

## Vercel preview

https://banx-ui-git-feature-ban-1175-frakt.vercel.app/