### PR TITLE
Disable borrowing on empty collection offerbook

### DIFF
--- a/src/pages/BorrowPage/components/BorrowTable/columns.tsx
+++ b/src/pages/BorrowPage/components/BorrowTable/columns.tsx
@@ -59,7 +59,7 @@ export const getTableColumns = ({
       render: (_, nft) => (
         <BorrowCell
           isCardView={isCardView}
-          disabled={!!findOfferInCart(nft)}
+          disabled={!!findOfferInCart(nft) || !nft.loanValue}
           onBorrow={() => onBorrow(nft)}
         />
       ),


### PR DESCRIPTION
## Description

Disable borrowing on empty collection offerboo

## Screenshots

<img width="1316" alt="image" src="https://github.com/frakt-solana/banx-ui/assets/60342317/9881b66a-9c6a-4a60-9b23-bcfe4e04dda2">

## Issue link

https://linear.app/banx-gg/issue/BAN-1163/fe-banx-disable-borrowing-on-empty-collection-offerbook

## Vercel preview

https://banx-ui-git-feature-ban-1163-frakt.vercel.app/
