### PR TITLE
Colors on dark mode

### DIFF
--- a/src/Layout/components/TopNotification/TopNotification.module.less
+++ b/src/Layout/components/TopNotification/TopNotification.module.less
@@ -23,7 +23,7 @@
 
 .content {
   flex-grow: 1;
-  color: var(--content-primary);
+  color: var(--pure-black);
 }
 
 .closeIcon {

--- a/src/components/Buttons/Buttons.module.less
+++ b/src/components/Buttons/Buttons.module.less
@@ -157,10 +157,14 @@
   width: 176px;
 
   svg path {
+    fill: var(--content-primary);
+  }
+
+  .walletIcon path {
     fill: var(--pure-black);
   }
 
-  .avatar path {
+  .avatarIcon path {
     fill: #888888;
   }
 }

--- a/src/components/Buttons/WalletConnectButton.tsx
+++ b/src/components/Buttons/WalletConnectButton.tsx
@@ -15,7 +15,7 @@ export const WalletConnectButton = () => {
 
   const ConnectedContent = () => (
     <>
-      <UserAvatar className={styles.avatar} />
+      <UserAvatar className={styles.avatarIcon} />
       <span>{shortenAddress(publicKey?.toBase58() || '')}</span>
       <ChevronDown />
     </>
@@ -23,7 +23,7 @@ export const WalletConnectButton = () => {
 
   const DisconnectedContent = () => (
     <>
-      <Wallet />
+      <Wallet className={styles.walletIcon} />
       <span>Connect wallet</span>
     </>
   )

--- a/src/components/SortDropdown/SortDropdown.module.less
+++ b/src/components/SortDropdown/SortDropdown.module.less
@@ -84,7 +84,12 @@
 .sortButton.active {
   background-color: var(--accent-primary);
   border-color: transparent;
+  color: var(--pure-black);
   pointer-events: none;
+
+  svg path {
+    fill: var(--pure-black);
+  }
 }
 
 .rotate {

--- a/src/less/abstracts/variables.less
+++ b/src/less/abstracts/variables.less
@@ -2,7 +2,6 @@
   //? Commons
   --border-less-primary: 0.5px solid var(--bg-border);
   --border-primary: 1px solid var(--bg-border);
-  --black-color: #000000;
 
   //? Colors - Light Theme (Default)
   --pure-black: #000000;

--- a/src/less/base/scrollBar.less
+++ b/src/less/base/scrollBar.less
@@ -7,7 +7,7 @@
 }
 
 ::-webkit-scrollbar-track {
-  background: var(--black-color);
+  background: var(--pure-color);
 }
 
 ::-webkit-scrollbar-thumb {

--- a/src/less/base/scrollBar.less
+++ b/src/less/base/scrollBar.less
@@ -7,7 +7,7 @@
 }
 
 ::-webkit-scrollbar-track {
-  background: var(--pure-color);
+  background: var(--pure-black);
 }
 
 ::-webkit-scrollbar-thumb {


### PR DESCRIPTION
Add "pure-black" color to active sort Buttons and TopNotification text Remove unnecessary "--black-color" variable

## Description

Rename "avatar" to "avatarIcon", add walletIcon, add color fill
Add "pure-black" color to active sort Buttons and TopNotification text
Remove unnecessary "--black-color" variable

## Screenshots

<img width="903" alt="image" src="https://github.com/frakt-solana/banx-ui/assets/60342317/74e0b53a-2f82-45c4-80b4-3bc70509d4d7">

## Issue link

https://linear.app/banx-gg/issue/BAN-1210/fe-banx-colors-on-dark-mode

## Vercel preview

https://banx-ui-git-feature-ban-1210-frakt.vercel.app/
