### PR TITLE
Improve search&select components style

### DIFF
--- a/src/components/SearchSelect/SearchSelect.module.less
+++ b/src/components/SearchSelect/SearchSelect.module.less
@@ -22,6 +22,10 @@
   @media (max-width: 640px) {
     height: 32px;
   }
+
+  &.active {
+    border-bottom: 1px solid transparent;
+  }
 }
 
 .prefix {

--- a/src/components/SearchSelect/SearchSelect.tsx
+++ b/src/components/SearchSelect/SearchSelect.tsx
@@ -54,7 +54,10 @@ export const SearchSelect = <P extends object>({
     )
 
   return (
-    <div ref={containerRef} className={classNames(styles.selectWrapper, className)}>
+    <div
+      ref={containerRef}
+      className={classNames(styles.selectWrapper, { [styles.active]: isPopupOpen }, className)}
+    >
       <PrefixInput />
       <AntdSelect
         mode="multiple"

--- a/src/less/antd/select.less
+++ b/src/less/antd/select.less
@@ -101,7 +101,6 @@
   border-top: 0;
   border-radius: 0;
   box-shadow: none;
-  color: var(--content-primary);
 
   font: var(--card-header-sm);
 
@@ -120,6 +119,10 @@
     color: var(--content-primary);
     padding: 8px;
     transition: none;
+  }
+
+  .ant-select-item:nth-child(odd) {
+    background: var(--bg-primary-deep);
   }
 
   .ant-select-item-option-active:not(.ant-select-item-option-disabled) {


### PR DESCRIPTION
Add background for popup with odd row

## Description

Remove border bottom when popup is opened

## Screenshots

<img width="898" alt="image" src="https://github.com/frakt-solana/banx-ui/assets/60342317/55e5531b-ee20-4696-9b0b-c0eeb09104d1">

## Issue link

https://linear.app/banx-gg/issue/BAN-1196/fe-improve-searchandselect-components-style

## Vercel preview

https://banx-ui-git-feature-ban-1195-frakt.vercel.app/
