### PR TITLE
Calc weighted APY on Refinance page

### DIFF
--- a/src/pages/RefinancePage/components/RefinanceTable/RefinanceTable.module.less
+++ b/src/pages/RefinancePage/components/RefinanceTable/RefinanceTable.module.less
@@ -27,7 +27,7 @@
   }
 }
 
-.aprCellValue {
+.aprValue {
   font: var(--important-text-md);
 }
 

--- a/src/pages/RefinancePage/components/RefinanceTable/Summary.tsx
+++ b/src/pages/RefinancePage/components/RefinanceTable/Summary.tsx
@@ -13,10 +13,12 @@ import { defaultTxnErrorHandler } from '@banx/transactions'
 import { TxnExecutor } from '@banx/transactions/TxnExecutor'
 import { makeRefinanceAction } from '@banx/transactions/loans'
 import {
+  HealthColorDecreasing,
   calcWeightedAverage,
   calculateLoanRepayValue,
   convertAprToApy,
   enqueueSnackbar,
+  getColorByPercent,
 } from '@banx/utils'
 
 import { useAuctionsLoans } from '../../hooks'
@@ -62,6 +64,7 @@ export const Summary: FC<SummaryProps> = ({
   })
 
   const weightedApy = calcWeightedAverage(totalApy, totalLoanValue)
+  const colorApy = getColorByPercent(weightedApy, HealthColorDecreasing)
 
   const refinanceAll = () => {
     const txnParams = selectedLoans.map((loan) => ({ loan }))
@@ -121,7 +124,9 @@ export const Summary: FC<SummaryProps> = ({
         </div>
         <div className={styles.stats}>
           <p>Weighted apy</p>
-          <p>{createPercentValueJSX(weightedApy)}</p>
+          <p style={{ color: weightedApy ? colorApy : '' }} className={styles.aprValue}>
+            {createPercentValueJSX(weightedApy, '0%')}
+          </p>
         </div>
       </div>
       <div className={styles.summaryBtns}>

--- a/src/pages/RefinancePage/components/RefinanceTable/TableCells/APRCell.tsx
+++ b/src/pages/RefinancePage/components/RefinanceTable/TableCells/APRCell.tsx
@@ -44,7 +44,7 @@ export const APRCell: FC<APRCellProps> = ({ loan }) => {
   const colorAPR = getColorByPercent(currentAPR, HealthColorDecreasing)
 
   return (
-    <span style={{ color: colorAPR }} className={styles.aprCellValue}>
+    <span style={{ color: colorAPR }} className={styles.aprValue}>
       {convertAprToApy(currentAPR / 100)}%
     </span>
   )

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,4 +1,4 @@
-import { flatMap, map, uniq } from 'lodash'
+import { flatMap, map, reduce, uniq } from 'lodash'
 
 import { BONDS, WEEKS_IN_YEAR } from '@banx/constants'
 
@@ -40,3 +40,18 @@ export const generateCSVContent = <T extends object>(dataList: T[]): string => {
 
 export const calcLoanValueWithProtocolFee = (loanValue: number) =>
   Math.floor(loanValue * (1 - BONDS.PROTOCOL_FEE_PERCENT / 1e4))
+
+export const calcWeightedAverage = (nums: number[], weights: number[]) => {
+  const [sum, weightSum] = reduce(
+    weights,
+    (acc, weight, i) => {
+      acc[0] += nums[i] * weight
+      acc[1] += weight
+      return acc
+    },
+    [0, 0],
+  )
+
+  const weightedAverage = sum / weightSum
+  return weightedAverage || 0
+}


### PR DESCRIPTION
## Description

Calc weighted APY on Refinance page

## Screenshots

<img width="1296" alt="image" src="https://github.com/frakt-solana/banx-ui/assets/60342317/1c048bb0-bb44-4756-ab38-5e98781f4939">

## Issue link

https://linear.app/banx-gg/issue/BAN-1155/fe-calc-weighted-apy-on-refinance-page

## Vercel preview

https://banx-ui-git-feature-ban-1155-frakt.vercel.app/
