### PR TITLE
Change background to "--pure-black" on select with cards

### DIFF
--- a/src/components/TableComponents/TableCells.module.less
+++ b/src/components/TableComponents/TableCells.module.less
@@ -29,7 +29,7 @@
   &:after {
     content: '';
     display: block;
-    background: var(--content-primary);
+    background: var(--pure-black);
     position: absolute;
     top: 50%;
     left: 50%;


### PR DESCRIPTION
## Description

Change background to "--pure-black" on select with cards

## Screenshots

<img width="431" alt="image" src="https://github.com/frakt-solana/banx-ui/assets/60342317/70230b26-c499-4bb7-8b9f-dfca1ae617ba">
<img width="546" alt="image" src="https://github.com/frakt-solana/banx-ui/assets/60342317/42da2b63-dff3-46ba-8c8b-b3e3b592df71">


## Issue link

https://linear.app/banx-gg/issue/BAN-1331/fe-banx-white-on-dark-mode-select-with-cards

## Vercel preview

https://banx-3jnhp7ph7-frakt.vercel.app/
