### PR TITLE
Replace "remove" icon in selected item in SearchSelect

### DIFF
--- a/src/less/antd/select.less
+++ b/src/less/antd/select.less
@@ -34,6 +34,19 @@
       width: 16px;
     }
 
+    .ant-select-selection-item-remove {
+      &::before {
+        content: '';
+        background: var(--content-primary);
+        display: flex;
+        height: 1px;
+        width: 10px;
+      }
+      span {
+        display: none;
+      }
+    }
+
     .searchSelectImageContainer > div {
       display: none;
     }


### PR DESCRIPTION
## Description

Replace "remove" icon in selected item in SearchSelect

## Screenshots

<img width="241" alt="image" src="https://github.com/frakt-solana/banx-ui/assets/60342317/418e0d83-e362-4d69-9b88-58e6c0015ae3">

## Issue link

https://linear.app/banx-gg/issue/BAN-1332/fe-replace-x-with-on-search-pills

## Vercel preview

https://banx-ui-git-fix-ban-1332-frakt.vercel.app/
