### PR TITLE
Add LTV indicator on My offers page (Pending tab)

### DIFF
--- a/src/api/core/types.ts
+++ b/src/api/core/types.ts
@@ -61,9 +61,7 @@ export const PairSchema = z.object({
 })
 
 export const UserPairSchema = PairSchema.merge(MarketMetaSchema).merge(
-  z.object({
-    collectionFloor: z.number().optional(), //TODO Make collectionFloor required
-  }),
+  z.object({ collectionFloor: z.number() }),
 )
 
 export type Offer = z.infer<typeof PairSchema>

--- a/src/api/core/types.ts
+++ b/src/api/core/types.ts
@@ -60,7 +60,11 @@ export const PairSchema = z.object({
   validation: ValidationPairSchema,
 })
 
-export const UserPairSchema = PairSchema.merge(MarketMetaSchema)
+export const UserPairSchema = PairSchema.merge(MarketMetaSchema).merge(
+  z.object({
+    collectionFloor: z.number().optional(), //TODO Make collectionFloor required
+  }),
+)
 
 export type Offer = z.infer<typeof PairSchema>
 export type UserOffer = z.infer<typeof UserPairSchema>

--- a/src/pages/OffersPage/components/ActiveOffersTable/ActiveOffersTable.module.less
+++ b/src/pages/OffersPage/components/ActiveOffersTable/ActiveOffersTable.module.less
@@ -33,6 +33,7 @@
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
+  gap: 4px;
 }
 
 .statusInfoTitle {

--- a/src/pages/OffersPage/components/ActiveOffersTable/TableCells/LentCell.tsx
+++ b/src/pages/OffersPage/components/ActiveOffersTable/TableCells/LentCell.tsx
@@ -3,7 +3,7 @@ import { FC } from 'react'
 import { createPercentValueJSX, createSolValueJSX } from '@banx/components/TableComponents'
 
 import { Loan } from '@banx/api/core'
-import { HealthColorIncreasing, getColorByPercent } from '@banx/utils'
+import { HealthColorDecreasing, getColorByPercent } from '@banx/utils'
 
 import styles from '../ActiveOffersTable.module.less'
 
@@ -35,7 +35,7 @@ export const LentCell: FC<LentCellProps> = ({ loan, isCardView }) => {
 }
 
 const createLtvValueJSX = (ltv: number) => {
-  const colorLTV = getColorByPercent(ltv, HealthColorIncreasing)
+  const colorLTV = getColorByPercent(ltv, HealthColorDecreasing)
 
   return (
     <span className={styles.lentInfoSubtitle} style={{ color: colorLTV }}>

--- a/src/pages/OffersPage/components/ActiveOffersTable/TableCells/LentCell.tsx
+++ b/src/pages/OffersPage/components/ActiveOffersTable/TableCells/LentCell.tsx
@@ -3,7 +3,7 @@ import { FC } from 'react'
 import { createPercentValueJSX, createSolValueJSX } from '@banx/components/TableComponents'
 
 import { Loan } from '@banx/api/core'
-import { HealthColorDecreasing, getColorByPercent } from '@banx/utils'
+import { HealthColorIncreasing, getColorByPercent } from '@banx/utils'
 
 import styles from '../ActiveOffersTable.module.less'
 
@@ -35,7 +35,7 @@ export const LentCell: FC<LentCellProps> = ({ loan, isCardView }) => {
 }
 
 const createLtvValueJSX = (ltv: number) => {
-  const colorLTV = getColorByPercent(ltv, HealthColorDecreasing)
+  const colorLTV = getColorByPercent(ltv, HealthColorIncreasing)
 
   return (
     <span className={styles.lentInfoSubtitle} style={{ color: colorLTV }}>

--- a/src/pages/OffersPage/components/PendingOffersTable/PendingOffersTable.module.less
+++ b/src/pages/OffersPage/components/PendingOffersTable/PendingOffersTable.module.less
@@ -23,6 +23,12 @@
   }
 }
 
+.offerCell {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
 .aprValue {
   font: var(--important-text-md);
 }

--- a/src/pages/OffersPage/components/PendingOffersTable/PendingOffersTable.module.less
+++ b/src/pages/OffersPage/components/PendingOffersTable/PendingOffersTable.module.less
@@ -29,6 +29,10 @@
   gap: 4px;
 }
 
+.offerCellSubtitle {
+  font: var(--body-text-sm);
+}
+
 .aprValue {
   font: var(--important-text-md);
 }

--- a/src/pages/OffersPage/components/PendingOffersTable/TableCells/OfferCell.tsx
+++ b/src/pages/OffersPage/components/PendingOffersTable/TableCells/OfferCell.tsx
@@ -2,7 +2,7 @@ import { FC } from 'react'
 
 import { createPercentValueJSX, createSolValueJSX } from '@banx/components/TableComponents'
 
-import { HealthColorDecreasing, getColorByPercent } from '@banx/utils'
+import { HealthColorIncreasing, getColorByPercent } from '@banx/utils'
 
 import { TableUserOfferData } from '../helpers'
 
@@ -33,7 +33,7 @@ export const OfferCell: FC<OfferCellProps> = ({ offer, isCardView }) => {
 }
 
 const createLtvValueJSX = (ltv: number) => {
-  const colorLTV = getColorByPercent(ltv, HealthColorDecreasing)
+  const colorLTV = getColorByPercent(ltv, HealthColorIncreasing)
 
   return (
     <span className={styles.offerCellSubtitle} style={{ color: colorLTV }}>

--- a/src/pages/OffersPage/components/PendingOffersTable/TableCells/OfferCell.tsx
+++ b/src/pages/OffersPage/components/PendingOffersTable/TableCells/OfferCell.tsx
@@ -1,0 +1,28 @@
+import { FC } from 'react'
+
+import { createPercentValueJSX, createSolValueJSX } from '@banx/components/TableComponents'
+
+import { HealthColorDecreasing, getColorByPercent } from '@banx/utils'
+
+import { TableUserOfferData } from '../helpers'
+
+import styles from '../PendingOffersTable.module.less'
+
+interface OfferCellProps {
+  offer: TableUserOfferData
+}
+
+export const OfferCell: FC<OfferCellProps> = ({ offer }) => {
+  const { loanValue, collectionFloor } = offer
+
+  const ltv = (loanValue / collectionFloor) * 100
+
+  const colorLTV = getColorByPercent(ltv, HealthColorDecreasing)
+
+  return (
+    <div className={styles.offerCell}>
+      <span>{createSolValueJSX(loanValue, 1e9)}</span>
+      <span style={{ color: colorLTV }}>{createPercentValueJSX(ltv)} LTV</span>
+    </div>
+  )
+}

--- a/src/pages/OffersPage/components/PendingOffersTable/TableCells/OfferCell.tsx
+++ b/src/pages/OffersPage/components/PendingOffersTable/TableCells/OfferCell.tsx
@@ -10,19 +10,34 @@ import styles from '../PendingOffersTable.module.less'
 
 interface OfferCellProps {
   offer: TableUserOfferData
+  isCardView: boolean
 }
 
-export const OfferCell: FC<OfferCellProps> = ({ offer }) => {
+export const OfferCell: FC<OfferCellProps> = ({ offer, isCardView }) => {
   const { loanValue, collectionFloor } = offer
 
   const ltv = (loanValue / collectionFloor) * 100
 
+  const formattedLoanValue = createSolValueJSX(loanValue, 1e9)
+
+  return !isCardView ? (
+    <div className={styles.offerCell}>
+      <span>{formattedLoanValue}</span>
+      {createLtvValueJSX(ltv)}
+    </div>
+  ) : (
+    <span>
+      {formattedLoanValue} ({createLtvValueJSX(ltv)})
+    </span>
+  )
+}
+
+const createLtvValueJSX = (ltv: number) => {
   const colorLTV = getColorByPercent(ltv, HealthColorDecreasing)
 
   return (
-    <div className={styles.offerCell}>
-      <span>{createSolValueJSX(loanValue, 1e9)}</span>
-      <span style={{ color: colorLTV }}>{createPercentValueJSX(ltv)} LTV</span>
-    </div>
+    <span className={styles.offerCellSubtitle} style={{ color: colorLTV }}>
+      {createPercentValueJSX(ltv)} LTV
+    </span>
   )
 }

--- a/src/pages/OffersPage/components/PendingOffersTable/TableCells/index.ts
+++ b/src/pages/OffersPage/components/PendingOffersTable/TableCells/index.ts
@@ -1,3 +1,4 @@
 export * from './ActionsCell'
 export * from './APRCell'
 export * from './InterestCell'
+export * from './OfferCell'

--- a/src/pages/OffersPage/components/PendingOffersTable/columns.tsx
+++ b/src/pages/OffersPage/components/PendingOffersTable/columns.tsx
@@ -24,7 +24,7 @@ export const getTableColumns = ({ isCardView }: { isCardView: boolean }) => {
     {
       key: 'offer',
       title: <HeaderCell label="Offer" />,
-      render: (_, offer) => <OfferCell offer={offer} />,
+      render: (_, offer) => <OfferCell offer={offer} isCardView={isCardView} />,
     },
     {
       key: 'loans',

--- a/src/pages/OffersPage/components/PendingOffersTable/columns.tsx
+++ b/src/pages/OffersPage/components/PendingOffersTable/columns.tsx
@@ -9,7 +9,7 @@ import {
 
 import { formatLoansAmount } from '@banx/utils'
 
-import { APRCell, ActionsCell, InterestCell } from './TableCells'
+import { APRCell, ActionsCell, InterestCell, OfferCell } from './TableCells'
 import { TableUserOfferData } from './helpers'
 
 export const getTableColumns = ({ isCardView }: { isCardView: boolean }) => {
@@ -24,7 +24,7 @@ export const getTableColumns = ({ isCardView }: { isCardView: boolean }) => {
     {
       key: 'offer',
       title: <HeaderCell label="Offer" />,
-      render: (_, { loanValue }) => createSolValueJSX(loanValue, 1e9),
+      render: (_, offer) => <OfferCell offer={offer} />,
     },
     {
       key: 'loans',

--- a/src/pages/OffersPage/components/PendingOffersTable/helpers.ts
+++ b/src/pages/OffersPage/components/PendingOffersTable/helpers.ts
@@ -26,7 +26,7 @@ export const parseUserOffers = (offers: UserOffer[]): TableUserOfferData[] => {
       collectionName,
       hadoMarket,
       assetReceiver,
-      collectionFloor = 0,
+      collectionFloor,
     } = offer
 
     const loansAmount = fundsSolOrTokenBalance / currentSpotPrice

--- a/src/pages/OffersPage/components/PendingOffersTable/helpers.ts
+++ b/src/pages/OffersPage/components/PendingOffersTable/helpers.ts
@@ -5,6 +5,7 @@ export interface TableUserOfferData {
   hadoMarket: string
   assetReceiver: string
 
+  collectionFloor: number
   collectionImage: string
   collectionName: string
 
@@ -25,6 +26,7 @@ export const parseUserOffers = (offers: UserOffer[]): TableUserOfferData[] => {
       collectionName,
       hadoMarket,
       assetReceiver,
+      collectionFloor = 0,
     } = offer
 
     const loansAmount = fundsSolOrTokenBalance / currentSpotPrice
@@ -36,6 +38,7 @@ export const parseUserOffers = (offers: UserOffer[]): TableUserOfferData[] => {
       publicKey,
       hadoMarket,
       assetReceiver,
+      collectionFloor,
       collectionImage,
       collectionName,
       loansAmount,

--- a/src/pages/OffersPage/hooks.ts
+++ b/src/pages/OffersPage/hooks.ts
@@ -72,6 +72,7 @@ export const useUserOffers = () => {
         return {
           ...offer,
           marketApr: marketPreview?.marketApr || 0,
+          collectionFloor: marketPreview?.collectionFloor || 0,
           collectionImage: marketPreview?.collectionImage || '',
           collectionName: marketPreview?.collectionName || '',
         }


### PR DESCRIPTION
Add OfferCell to PendingOffersTable (Add LTV)

## Description

Add collectionFloor to UserPairSchema
Add LTV indicator on My offers page (Pending tab)
Change LTV colors

## Screenshots

<img width="770" alt="image" src="https://github.com/frakt-solana/banx-ui/assets/60342317/499f970b-95ce-4d5a-b263-5ae2d15db9a5">

<img width="426" alt="image" src="https://github.com/frakt-solana/banx-ui/assets/60342317/b8c84cda-fe90-454e-857e-d6b3b32774c2">



## Issue link

https://linear.app/banx-gg/issue/BAN-1322/fe-add-ltv-indicator-on-my-offers-page-pending-tab

## Vercel preview

https://banx-ui-git-feature-ban-1322-frakt.vercel.app/
