### PR TITLE
Add filters to pending offers tab and active offers tab

### DIFF
--- a/src/pages/OffersPage/components/ActiveOffersTable/hooks/useActiveOffersTable.ts
+++ b/src/pages/OffersPage/components/ActiveOffersTable/hooks/useActiveOffersTable.ts
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react'
 
 import { useWallet } from '@solana/wallet-adapter-react'
-import { first, groupBy, map, sumBy } from 'lodash'
+import { filter, first, groupBy, includes, map, sumBy } from 'lodash'
 import { useNavigate } from 'react-router-dom'
 
 import { SearchSelectProps } from '@banx/components/SearchSelect'
@@ -65,7 +65,14 @@ export const useActiveOffersTable = () => {
     className: styles.sortDropdown,
   }
 
-  const sortedLoans = useSortedLenderLoans(loans, sortOption.value)
+  const filteredLoans = useMemo(() => {
+    if (selectedOptions.length) {
+      return filter(loans, ({ nft }) => includes(selectedOptions, nft.meta.collectionName))
+    }
+    return loans
+  }, [loans, selectedOptions])
+
+  const sortedLoans = useSortedLenderLoans(filteredLoans, sortOption.value)
 
   const showEmptyList = (!loans?.length && !loading) || !connected
 

--- a/src/pages/OffersPage/components/PendingOffersTable/hooks/usePendingOfferTable.ts
+++ b/src/pages/OffersPage/components/PendingOffersTable/hooks/usePendingOfferTable.ts
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react'
 
 import { useWallet } from '@solana/wallet-adapter-react'
-import { first, groupBy, map } from 'lodash'
+import { filter, first, groupBy, includes, map } from 'lodash'
 import { useNavigate } from 'react-router-dom'
 
 import { SearchSelectProps } from '@banx/components/SearchSelect'
@@ -72,7 +72,14 @@ export const usePendingOfferTable = () => {
     className: styles.searchSelect,
   }
 
-  const parsedUserOffers = parseUserOffers(offers)
+  const filteredOffers = useMemo(() => {
+    if (selectedOptions.length) {
+      return filter(offers, ({ collectionName }) => includes(selectedOptions, collectionName))
+    }
+    return offers
+  }, [offers, selectedOptions])
+
+  const parsedUserOffers = parseUserOffers(filteredOffers)
   const sortedOffers = useSortedOffers(parsedUserOffers, sortOption.value)
 
   const sortParams = {


### PR DESCRIPTION
## Description

Add filters to pending offers tab and active offers tab

## Screenshots

<img width="1298" alt="image" src="https://github.com/frakt-solana/banx-ui/assets/60342317/aad395ce-1e19-4206-9e91-31ad2b6e951a">


## Issue link

https://linear.app/banx-gg/issue/BAN-1342/fe-banx-fix-collection-select-on-my-offers-page

## Vercel preview

https://banx-ui-git-fix-ban-1342-frakt.vercel.app/
