### PR TITLE
BAN-1371: Stop txns queue if wallet rejects txn

### DIFF
--- a/src/pages/BorrowPage/components/BorrowTable/helpers.ts
+++ b/src/pages/BorrowPage/components/BorrowTable/helpers.ts
@@ -69,7 +69,7 @@ export const executeBorrow = async (props: {
   const txnsResults = await new TxnExecutor(
     makeBorrowAction,
     { wallet, connection },
-    { signAllChunks: isLedger ? 1 : 40, rejectQueueOnFirstPfError: true },
+    { signAllChunks: isLedger ? 1 : 40, rejectQueueOnFirstPfError: false },
   )
     .addTxnParams(txnParams)
     .on('pfSuccessEach', (results) => {

--- a/src/pages/LoansPage/components/LoansActiveTable/hooks/useLoansTransactions.ts
+++ b/src/pages/LoansPage/components/LoansActiveTable/hooks/useLoansTransactions.ts
@@ -82,7 +82,7 @@ export const useLoansTransactions = () => {
     await new TxnExecutor(
       makeRepayLoansAction,
       { wallet, connection },
-      { rejectQueueOnFirstPfError: true },
+      { rejectQueueOnFirstPfError: false },
     )
       .addTxnParams(loansChunks)
       .on('pfSuccessEach', (results) => {

--- a/src/transactions/TxnExecutor/TxnExecutor.ts
+++ b/src/transactions/TxnExecutor/TxnExecutor.ts
@@ -3,7 +3,7 @@ import { chunk } from 'lodash'
 import { WalletAndConnection } from '@banx/types'
 
 import { TxnError } from '../types'
-import { signAndSendTxns } from './helpers'
+import { hasUserRejectedTxnApprove, signAndSendTxns } from './helpers'
 import { EventHanlders, ExecutorOptions, MakeActionFn } from './types'
 
 export const DEFAULT_EXECUTOR_OPTIONS: ExecutorOptions = {
@@ -83,7 +83,9 @@ export class TxnExecutor<TParams, TResult> {
           signAndSendTxnsResults.push(...result)
         } catch (error) {
           eventHandlers?.pfError?.(error as TxnError)
-          if (options.rejectQueueOnFirstPfError) return
+          const userRejectedTxn = hasUserRejectedTxnApprove(error as TxnError)
+          if (userRejectedTxn) return
+          if (!userRejectedTxn && options.rejectQueueOnFirstPfError) return
         }
       }
 
@@ -124,7 +126,9 @@ export class TxnExecutor<TParams, TResult> {
           signAndSendTxnsResults.push(...result)
         } catch (error) {
           eventHandlers?.pfError?.(error as TxnError)
-          if (options.rejectQueueOnFirstPfError) return
+          const userRejectedTxn = hasUserRejectedTxnApprove(error as TxnError)
+          if (userRejectedTxn) return
+          if (!userRejectedTxn && options.rejectQueueOnFirstPfError) return
         }
       }
 

--- a/src/transactions/TxnExecutor/constants.ts
+++ b/src/transactions/TxnExecutor/constants.ts
@@ -1,0 +1,2 @@
+//? To define that user has rejected txn (check error.message). 0 -- phantom error message, 1 -- solflare error message
+export const USER_REJECTED_TXN_ERR_MESSAGES = ['User rejected the request.', 'Transaction rejected']

--- a/src/transactions/TxnExecutor/helpers.ts
+++ b/src/transactions/TxnExecutor/helpers.ts
@@ -2,6 +2,8 @@ import { web3 } from 'fbonds-core'
 
 import { WalletAndConnection } from '@banx/types'
 
+import { TxnError } from '../types'
+import { USER_REJECTED_TXN_ERR_MESSAGES } from './constants'
 import { EventHanlders, ExecutorOptions, SendTxnsResult, TxnData } from './types'
 
 export const signAndSendTxns = async <TResult>({
@@ -106,4 +108,12 @@ const fetchLookupTableAccount = (lookupTable: web3.PublicKey, connection: web3.C
   }
 
   return lookupTablesCache.get(lookupTableAddressStr)!
+}
+
+export const hasUserRejectedTxnApprove = (error: TxnError) => {
+  const { message } = error
+  if (USER_REJECTED_TXN_ERR_MESSAGES.includes(message)) {
+    return true
+  }
+  return false
 }


### PR DESCRIPTION
## Description

Stop txns queue (bulk txns in TxnExecutor) when the user rejects txn in the wallet modal.
Even if `rejectQueueOnFirstPfError:false`


## Issue link

https://linear.app/banx-gg/issue/BAN-1371/fe-stop-txns-queue-if-wallet-rejects-txn

## Vercel preview

https://banx-ui-git-feauture-ban-1371-frakt.vercel.app/
