### PR TITLE
Add formatted values with commas to DashboardHeader and LendHeader

### DIFF
--- a/src/pages/DashboardPage/components/DashboardHeader/DashboardHeader.tsx
+++ b/src/pages/DashboardPage/components/DashboardHeader/DashboardHeader.tsx
@@ -6,6 +6,8 @@ import {
 } from '@banx/components/PageHeader'
 import { VALUES_TYPES } from '@banx/components/StatInfo'
 
+import { formatNumbersWithCommas } from '@banx/utils'
+
 import { useAllTotalStats } from '../../hooks'
 
 import styles from './DashboardHeader.module.less'
@@ -23,7 +25,11 @@ const Header = () => {
   return (
     <PageHeaderBackdrop className={styles.container} title="Dashboard">
       <AdditionalStat label="Daily volume" value={dailyVolume} divider={1e9} decimalPlaces={0} />
-      <AdditionalStat label="Active loans" value={activeLoans} valueType={VALUES_TYPES.STRING} />
+      <AdditionalStat
+        label="Active loans"
+        value={formatNumbersWithCommas(activeLoans)}
+        valueType={VALUES_TYPES.STRING}
+      />
       <AdditionalStat
         label="Total value locked"
         value={totalValueLocked}

--- a/src/pages/LendPage/components/LendHeader/LendHeader.tsx
+++ b/src/pages/LendPage/components/LendHeader/LendHeader.tsx
@@ -9,7 +9,9 @@ import {
   SeparateStatsLine,
 } from '@banx/components/PageHeader'
 import { VALUES_TYPES } from '@banx/components/StatInfo'
-import { createSolValueJSX } from '@banx/components/TableComponents'
+
+import { MarketPreview } from '@banx/api/core'
+import { formatNumbersWithCommas } from '@banx/utils'
 
 import { useMarketsPreview } from '../../hooks'
 
@@ -18,21 +20,19 @@ import styles from './LendHeader.module.less'
 const Header = () => {
   const { marketsPreview } = useMarketsPreview()
 
-  const { totalLoans, totalOffers, formattedLoansTVL, formattedOffersTVL } = useMemo(() => {
-    const loansTVL = sumBy(marketsPreview, 'loansTvl')
-    const offersTVL = sumBy(marketsPreview, 'offerTvl')
-    const totalLoans = sumBy(marketsPreview, 'activeBondsAmount')
-    const totalOffers = sumBy(marketsPreview, 'activeOfferAmount')
+  const { loansTVL, offersTVL, totalLoans, totalOffers } = useMemo(() => {
+    const sumByKey = (key: keyof MarketPreview) => sumBy(marketsPreview, key)
 
     return {
-      loansTVL,
-      offersTVL,
-      totalLoans,
-      totalOffers,
-      formattedLoansTVL: createSolValueJSX(loansTVL, 1e9),
-      formattedOffersTVL: createSolValueJSX(offersTVL, 1e9),
+      loansTVL: sumByKey('loansTvl'),
+      offersTVL: sumByKey('offerTvl'),
+      totalLoans: sumByKey('activeBondsAmount'),
+      totalOffers: sumByKey('activeOfferAmount'),
     }
   }, [marketsPreview])
+
+  const formattedLoansTVL = formatNumbersWithCommas((loansTVL / 1e9)?.toFixed(0))
+  const formattedOffersTVL = formatNumbersWithCommas((offersTVL / 1e9)?.toFixed(0))
 
   return (
     <PageHeaderBackdrop title="Lend">
@@ -40,8 +40,7 @@ const Header = () => {
         label="Loans volume"
         value={
           <>
-            {formattedLoansTVL}
-            <span className={styles.value}>in {totalLoans} loans</span>
+            {formattedLoansTVL}◎<span className={styles.value}>in {totalLoans} loans</span>
           </>
         }
         valueType={VALUES_TYPES.STRING}
@@ -51,8 +50,7 @@ const Header = () => {
         label="Offers TVL"
         value={
           <>
-            {formattedOffersTVL}
-            <span className={styles.value}>in {totalOffers} offers</span>
+            {formattedOffersTVL}◎<span className={styles.value}>in {totalOffers} offers</span>
           </>
         }
         valueType={VALUES_TYPES.STRING}

--- a/src/pages/LendPage/components/LendHeader/LendHeader.tsx
+++ b/src/pages/LendPage/components/LendHeader/LendHeader.tsx
@@ -40,7 +40,8 @@ const Header = () => {
         label="Loans volume"
         value={
           <>
-            {formattedLoansTVL}◎<span className={styles.value}>in {totalLoans} loans</span>
+            {formattedLoansTVL}◎
+            <span className={styles.value}>in {formatNumbersWithCommas(totalLoans)} loans</span>
           </>
         }
         valueType={VALUES_TYPES.STRING}
@@ -50,7 +51,8 @@ const Header = () => {
         label="Offers TVL"
         value={
           <>
-            {formattedOffersTVL}◎<span className={styles.value}>in {totalOffers} offers</span>
+            {formattedOffersTVL}◎
+            <span className={styles.value}>in {formatNumbersWithCommas(totalOffers)} offers</span>
           </>
         }
         valueType={VALUES_TYPES.STRING}


### PR DESCRIPTION
## Description

Add formatted values with commas to DashboardHeader and LendHeader

## Screenshots

<img width="1295" alt="image" src="https://github.com/frakt-solana/banx-ui/assets/60342317/8d4b351a-d731-46f6-bc63-4020e988ab19">

## Issue link

https://linear.app/banx-gg/issue/BAN-1370/fe-banx-dashboard-and-lend-stats-roundings

## Vercel preview

https://banx-ui-git-feature-ban-1370-frakt.vercel.app/
