### PR TITLE
BAN-1338: Show highlight colors only if LiquidationLoansCount exists

### DIFF
--- a/src/pages/DashboardPage/components/DashboardBorrowTab/components/MyLoans/constants.ts
+++ b/src/pages/DashboardPage/components/DashboardBorrowTab/components/MyLoans/constants.ts
@@ -13,7 +13,7 @@ export const STATUS_COLOR_MAP: Record<LoansStatus, string> = {
 export const STATUS_DISPLAY_NAMES: Record<LoansStatus, string> = {
   [LoansStatus.Active]: 'Active Loans',
   [LoansStatus.Terminating]: 'Terminating Loans',
-  [LoansStatus.Liquidation]: 'Liquidation during 24h',
+  [LoansStatus.Liquidation]: 'Liquidating within 24h',
 }
 
 export const NO_DATA_CHART_DATA = {

--- a/src/pages/DashboardPage/components/DashboardBorrowTab/components/MyLoans/hooks.ts
+++ b/src/pages/DashboardPage/components/DashboardBorrowTab/components/MyLoans/hooks.ts
@@ -31,7 +31,7 @@ export const useMyLoans = (stats?: TotalBorrowerStats | null) => {
   }
 
   const loansData = map(loansStatusToValueMap, (value, status) => ({
-    className: status === LoansStatus.Liquidation && styles.highlightLiquidation,
+    className: liquidationLoansCount && styles.highlightLiquidation,
     label: STATUS_DISPLAY_NAMES[status as LoansStatus],
     key: status,
     value,


### PR DESCRIPTION
Rename "Liquidation during 24h" => "Liquidating within 24h"

## Description

Show highlight colors only if LiquidationLoansCount exists
Rename "Liquidation during 24h" => "Liquidating within 24h"

## Screenshots

<img width="665" alt="image" src="https://github.com/frakt-solana/banx-ui/assets/60342317/697e60bd-5b16-49b0-83fe-8b7dcbaefa28">

## Issue link

https://linear.app/banx-gg/issue/BAN-1338/fe-banx-liquidating-during-24h-should-not-be-highlighted-when-no

## Vercel preview

https://banx-ui-git-feature-ban-1338-frakt.vercel.app/
