### PR TITLE
BAN-1389: Do not stretch buttons as resolution increases

### DIFF
--- a/src/pages/BorrowPage/components/BorrowTable/BorrowCell.tsx
+++ b/src/pages/BorrowPage/components/BorrowTable/BorrowCell.tsx
@@ -29,7 +29,7 @@ export const BorrowCell: FC<BorrowCellProps> = ({
   return (
     <Button
       className={styles.borrowButton}
-      size={isCardView ? 'large' : 'small'}
+      size={isCardView ? 'medium' : 'small'}
       disabled={disabled}
       loading={isBorrowing}
       onClick={onClickHandler}

--- a/src/pages/BorrowPage/components/BorrowTable/BorrowTable.module.less
+++ b/src/pages/BorrowPage/components/BorrowTable/BorrowTable.module.less
@@ -157,7 +157,7 @@
 }
 
 .borrowButton {
-  width: 128px;
+  width: 104px;
 }
 
 .selectButtonText {

--- a/src/pages/LoansPage/components/LoansActiveTable/LoansActiveTable.module.less
+++ b/src/pages/LoansPage/components/LoansActiveTable/LoansActiveTable.module.less
@@ -38,6 +38,7 @@
 .debtInfo {
   display: flex;
   flex-direction: column;
+  white-space: nowrap;
   align-items: flex-end;
   gap: 4px;
 }

--- a/src/pages/LoansPage/components/LoansActiveTable/TableCells/ActionsCell/ActionsCell.module.less
+++ b/src/pages/LoansPage/components/LoansActiveTable/TableCells/ActionsCell/ActionsCell.module.less
@@ -6,10 +6,6 @@
   width: 100%;
 }
 
-.refinanceBtn {
-  flex-grow: 1;
-}
-
 .repayModalInfo {
   display: flex;
   justify-content: flex-start;

--- a/src/pages/LoansPage/components/LoansActiveTable/TableCells/ActionsCell/ActionsCell.module.less
+++ b/src/pages/LoansPage/components/LoansActiveTable/TableCells/ActionsCell/ActionsCell.module.less
@@ -116,3 +116,8 @@
     font: var(--table-header-sm);
   }
 }
+
+.refinanceButton,
+.repayButton {
+  width: 104px;
+}

--- a/src/pages/LoansPage/components/LoansActiveTable/TableCells/ActionsCell/ActionsCell.tsx
+++ b/src/pages/LoansPage/components/LoansActiveTable/TableCells/ActionsCell/ActionsCell.tsx
@@ -42,7 +42,8 @@ export const ActionsCell: FC<ActionsCellProps> = ({ loan, isCardView, disableAct
   return (
     <div className={styles.actionsButtons}>
       <Button
-        size={isCardView ? 'large' : 'small'}
+        className={styles.refinanceButton}
+        size={isCardView ? 'medium' : 'small'}
         variant="secondary"
         disabled={disableActions || !offerToRefinance}
         onClick={(event) => {
@@ -53,7 +54,8 @@ export const ActionsCell: FC<ActionsCellProps> = ({ loan, isCardView, disableAct
         {isTerminatingStatus ? 'Extend' : 'Reborrow'}
       </Button>
       <Button
-        size={isCardView ? 'large' : 'small'}
+        className={styles.repayButton}
+        size={isCardView ? 'medium' : 'small'}
         disabled={disableActions}
         onClick={(event) => {
           open(RepayModal, { loan })

--- a/src/pages/LoansPage/components/LoansActiveTable/TableCells/ActionsCell/ActionsCell.tsx
+++ b/src/pages/LoansPage/components/LoansActiveTable/TableCells/ActionsCell/ActionsCell.tsx
@@ -42,7 +42,6 @@ export const ActionsCell: FC<ActionsCellProps> = ({ loan, isCardView, disableAct
   return (
     <div className={styles.actionsButtons}>
       <Button
-        className={styles.refinanceBtn}
         size={isCardView ? 'large' : 'small'}
         variant="secondary"
         disabled={disableActions || !offerToRefinance}

--- a/src/pages/OffersPage/components/ActiveOffersTable/ActiveOffersTable.module.less
+++ b/src/pages/OffersPage/components/ActiveOffersTable/ActiveOffersTable.module.less
@@ -23,11 +23,6 @@
   width: 100%;
 }
 
-.terminateButton,
-.instantButton {
-  width: 100%;
-}
-
 .lentInfo,
 .statusInfo {
   display: flex;

--- a/src/pages/OffersPage/components/ActiveOffersTable/ActiveOffersTable.module.less
+++ b/src/pages/OffersPage/components/ActiveOffersTable/ActiveOffersTable.module.less
@@ -21,10 +21,10 @@
   justify-content: flex-end;
   gap: 8px;
   width: 100%;
+}
 
-  button {
-    width: 104px;
-  }
+.actionButton {
+  width: 104px;
 }
 
 .lentInfo,

--- a/src/pages/OffersPage/components/ActiveOffersTable/ActiveOffersTable.module.less
+++ b/src/pages/OffersPage/components/ActiveOffersTable/ActiveOffersTable.module.less
@@ -21,6 +21,10 @@
   justify-content: flex-end;
   gap: 8px;
   width: 100%;
+
+  button {
+    width: 104px;
+  }
 }
 
 .lentInfo,

--- a/src/pages/OffersPage/components/ActiveOffersTable/TableCells/ActionsCell.tsx
+++ b/src/pages/OffersPage/components/ActiveOffersTable/TableCells/ActionsCell.tsx
@@ -86,7 +86,6 @@ export const ActionsCell: FC<ActionsCellProps> = ({ loan, isCardView }) => {
     <div className={styles.actionsButtons}>
       {showTerminateButton && (
         <Button
-          className={styles.terminateButton}
           onClick={onTerminate}
           disabled={isTerminatingStatus}
           variant="secondary"
@@ -97,17 +96,12 @@ export const ActionsCell: FC<ActionsCellProps> = ({ loan, isCardView }) => {
       )}
 
       {showInstantButton && (
-        <Button
-          onClick={onInstant}
-          className={styles.instantButton}
-          variant="secondary"
-          size={buttonSize}
-        >
+        <Button onClick={onInstant} variant="secondary" size={buttonSize}>
           Instant
         </Button>
       )}
       {showClaimButton && (
-        <Button onClick={onClaim} className={styles.instantButton} size={buttonSize}>
+        <Button onClick={onClaim} size={buttonSize}>
           Claim NFT
         </Button>
       )}

--- a/src/pages/OffersPage/components/ActiveOffersTable/TableCells/ActionsCell.tsx
+++ b/src/pages/OffersPage/components/ActiveOffersTable/TableCells/ActionsCell.tsx
@@ -86,6 +86,7 @@ export const ActionsCell: FC<ActionsCellProps> = ({ loan, isCardView }) => {
     <div className={styles.actionsButtons}>
       {showTerminateButton && (
         <Button
+          className={styles.actionButton}
           onClick={onTerminate}
           disabled={isTerminatingStatus}
           variant="secondary"
@@ -96,12 +97,17 @@ export const ActionsCell: FC<ActionsCellProps> = ({ loan, isCardView }) => {
       )}
 
       {showInstantButton && (
-        <Button onClick={onInstant} variant="secondary" size={buttonSize}>
+        <Button
+          className={styles.actionButton}
+          onClick={onInstant}
+          variant="secondary"
+          size={buttonSize}
+        >
           Instant
         </Button>
       )}
       {showClaimButton && (
-        <Button onClick={onClaim} size={buttonSize}>
+        <Button className={styles.actionButton} onClick={onClaim} size={buttonSize}>
           Claim NFT
         </Button>
       )}

--- a/src/pages/OffersPage/components/ActiveOffersTable/TableCells/ActionsCell.tsx
+++ b/src/pages/OffersPage/components/ActiveOffersTable/TableCells/ActionsCell.tsx
@@ -69,7 +69,7 @@ export const ActionsCell: FC<ActionsCellProps> = ({ loan, isCardView }) => {
     claimLoan()
   }
 
-  const buttonSize = isCardView ? 'large' : 'small'
+  const buttonSize = isCardView ? 'medium' : 'small'
 
   const loanActiveOrRefinanced = isLoanActiveOrRefinanced(loan)
   const isTerminatingStatus = isLoanTerminating(loan)

--- a/src/pages/OffersPage/components/PendingOffersTable/PendingOffersTable.module.less
+++ b/src/pages/OffersPage/components/PendingOffersTable/PendingOffersTable.module.less
@@ -13,6 +13,10 @@
   justify-content: flex-end;
   gap: 8px;
   width: 100%;
+
+  button {
+    width: 104px;
+  }
 }
 
 .removeButton {

--- a/src/pages/OffersPage/components/PendingOffersTable/PendingOffersTable.module.less
+++ b/src/pages/OffersPage/components/PendingOffersTable/PendingOffersTable.module.less
@@ -13,10 +13,11 @@
   justify-content: flex-end;
   gap: 8px;
   width: 100%;
+}
 
-  button {
-    width: 104px;
-  }
+.actionButton,
+.removeButton {
+  width: 104px;
 }
 
 .removeButton {

--- a/src/pages/OffersPage/components/PendingOffersTable/TableCells/ActionsCell.tsx
+++ b/src/pages/OffersPage/components/PendingOffersTable/TableCells/ActionsCell.tsx
@@ -26,7 +26,7 @@ interface ActionsCellProps {
 export const ActionsCell: FC<ActionsCellProps> = ({ offer, isCardView }) => {
   const { removeOffer, goToEditOffer } = useActionsCell(offer)
 
-  const buttonSize = isCardView ? 'large' : 'small'
+  const buttonSize = isCardView ? 'medium' : 'small'
 
   const onEdit = () => {
     goToEditOffer()

--- a/src/pages/OffersPage/components/PendingOffersTable/TableCells/ActionsCell.tsx
+++ b/src/pages/OffersPage/components/PendingOffersTable/TableCells/ActionsCell.tsx
@@ -40,12 +40,17 @@ export const ActionsCell: FC<ActionsCellProps> = ({ offer, isCardView }) => {
 
   return (
     <div className={styles.actionsButtons}>
-      <Button onClick={onEdit} variant="secondary" size={buttonSize}>
+      <Button
+        className={styles.actionButton}
+        onClick={onEdit}
+        variant="secondary"
+        size={buttonSize}
+      >
         Edit
       </Button>
       <Button
-        onClick={onRemove}
         className={styles.removeButton}
+        onClick={onRemove}
         variant="secondary"
         size={buttonSize}
       >

--- a/src/pages/RefinancePage/components/RefinanceTable/RefinanceTable.module.less
+++ b/src/pages/RefinancePage/components/RefinanceTable/RefinanceTable.module.less
@@ -168,7 +168,7 @@
 }
 
 .borrowButton {
-  width: 128px;
+  width: 104px;
 }
 
 .selectButtonText {

--- a/src/pages/RefinancePage/components/RefinanceTable/TableCells/RefinanceCell.tsx
+++ b/src/pages/RefinancePage/components/RefinanceTable/TableCells/RefinanceCell.tsx
@@ -35,7 +35,7 @@ export const RefinanceCell: FC<RefinanceCellProps> = ({ loan, isCardView }) => {
   const { toggleVisibility } = useWalletModal()
 
   const refinance = useRefinanceTransaction(loan)
-  const buttonSize = isCardView ? 'large' : 'small'
+  const buttonSize = isCardView ? 'medium' : 'small'
 
   const onClickHandler = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     if (connected) {


### PR DESCRIPTION
## Description

 Do not stretch buttons as resolution increases
 Set width 92px for all tables buttons
Change button size to medium for cards view

## Screenshots

<img width="1316" alt="image" src="https://github.com/frakt-solana/banx-ui/assets/60342317/041f900f-af7e-41bc-bc79-8c9184a36227">


## Issue link

https://linear.app/banx-gg/issue/BAN-1389/fe-banx-do-not-stretch-buttons-as-resolution-increases

## Vercel preview

https://banx-ui-git-feature-ban-1389-frakt.vercel.app/
