### PR TITLE
BAN-1381: Do not deselect checkboxes on isLedger checked repay

### DIFF
--- a/src/pages/LoansPage/components/LoansActiveTable/hooks/useLoansTransactions.ts
+++ b/src/pages/LoansPage/components/LoansActiveTable/hooks/useLoansTransactions.ts
@@ -97,6 +97,8 @@ export const useLoansTransactions = () => {
             updateLoansOptimistic(result, wallet.publicKey.toBase58())
           }
         })
+      })
+      .on('pfSuccessAll', () => {
         clearSelection()
       })
       .on('pfError', (error) => {


### PR DESCRIPTION
## Description

Add clearSelection only after pfSuccessAll in repayBulkLoan

## Screenshots

<!-- If applicable -->

## Issue link

https://linear.app/banx-gg/issue/BAN-1381/fe-banx-do-not-deselect-checkboxes-on-isledger-checked-repay

## Vercel preview

https://banx-ui-git-fix-ban-1381-frakt.vercel.app/
