### PR TITLE
BAN-1430: Fix tooltip bg on Dashboard

### DIFF
--- a/src/components/Charts/Charts.module.less
+++ b/src/components/Charts/Charts.module.less
@@ -12,6 +12,7 @@
   flex-direction: column;
   align-items: center;
   gap: 4px;
+  z-index: -1;
 
   & > div {
     white-space: nowrap;


### PR DESCRIPTION
## Description

Reduce zIndex on doughnut inner content to get rid of tooltip transparent

## Screenshots

### Before 
<img width="175" alt="image" src="https://github.com/frakt-solana/banx-ui/assets/60342317/05e5cf37-aa19-4a2c-929d-0ece8ee7676a">


### After
<img width="166" alt="image" src="https://github.com/frakt-solana/banx-ui/assets/60342317/661f982d-cfff-470a-9a16-c9a2a8c713de">


## Issue link

https://linear.app/banx-gg/issue/BAN-1430/fe-banx-fix-tooltip-bg-on-dashboard

## Vercel preview

https://banx-ui-git-fix-ban-1430-frakt.vercel.app/
