### PR TITLE
BAN-1294: Fix horizontal gaps and icon size in "sort" buttons

### DIFF
--- a/src/components/SortDropdown/SortDropdown.module.less
+++ b/src/components/SortDropdown/SortDropdown.module.less
@@ -49,6 +49,7 @@
 .dropdownButtonTextContainer {
   display: flex;
   align-items: center;
+  gap: 4px;
 }
 .dropdownButtonText {
   display: flex;
@@ -92,7 +93,12 @@
   border-color: var(--bg-border);
   display: flex;
   align-items: center;
+
+  font: var(--tab-text-md);
+  gap: 4px;
+
   white-space: nowrap;
+  height: 32px;
 }
 
 .sortButton.active {

--- a/src/components/SortDropdown/SortDropdown.module.less
+++ b/src/components/SortDropdown/SortDropdown.module.less
@@ -46,6 +46,10 @@
     min-width: 180px;
   }
 }
+.dropdownButtonTextContainer {
+  display: flex;
+  align-items: center;
+}
 .dropdownButtonText {
   display: flex;
   align-items: center;
@@ -58,10 +62,15 @@
     fill: var(--content-primary);
   }
 
-  @media screen and (max-width: 640px) {
+  svg {
+    height: 18px;
+    width: 18px;
+  }
+
+  @media (max-width: 640px) {
     svg {
-      height: 18px;
-      width: 18px;
+      height: 16px;
+      width: 16px;
     }
   }
 }

--- a/src/components/SortDropdown/SortDropdown.module.less
+++ b/src/components/SortDropdown/SortDropdown.module.less
@@ -39,11 +39,11 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  min-width: 200px;
+  min-width: 170px;
   width: 100%;
 
   @media screen and (max-width: 640px) {
-    min-width: 180px;
+    min-width: 150px;
   }
 }
 .dropdownButtonTextContainer {
@@ -54,6 +54,11 @@
   display: flex;
   align-items: center;
   white-space: nowrap;
+  font: var(--btn-text-md);
+
+  @media screen and (max-width: 640px) {
+    font: var(--btn-text-sm);
+  }
 }
 
 .dropdownButton,
@@ -63,8 +68,8 @@
   }
 
   svg {
-    height: 18px;
-    width: 18px;
+    height: 20px;
+    width: 20px;
   }
 
   @media (max-width: 640px) {

--- a/src/components/SortDropdown/components.tsx
+++ b/src/components/SortDropdown/components.tsx
@@ -44,8 +44,8 @@ const SortButton: FC<SortButtonProps> = ({ option, sortOrder, isActive, onClick 
     variant="text"
     onClick={onClick}
   >
-    {option.label}
     <ArrowDown className={getSortOrderClassName(sortOrder)} />
+    {option.label}
   </Button>
 )
 

--- a/src/components/SortDropdown/components.tsx
+++ b/src/components/SortDropdown/components.tsx
@@ -22,7 +22,6 @@ export const DropdownButton: FC<DropdownButtonProps> = ({
   toggleDropdown,
 }) => (
   <Button type="circle" variant="text" className={styles.dropdownButton} onClick={toggleDropdown}>
-    <span className={styles.dropdownButtonText}>Sort:</span>
     <div className={styles.dropdownButtonTextContainer}>
       <ArrowDown className={getSortOrderClassName(sortOption.value)} />
       <span className={styles.dropdownButtonText}>{sortOption?.label}</span>

--- a/src/components/SortDropdown/components.tsx
+++ b/src/components/SortDropdown/components.tsx
@@ -23,8 +23,10 @@ export const DropdownButton: FC<DropdownButtonProps> = ({
 }) => (
   <Button type="circle" variant="text" className={styles.dropdownButton} onClick={toggleDropdown}>
     <span className={styles.dropdownButtonText}>Sort:</span>
-    <ArrowDown className={getSortOrderClassName(sortOption.value)} />
-    <span className={styles.dropdownButtonText}>{sortOption?.label}</span>
+    <div className={styles.dropdownButtonTextContainer}>
+      <ArrowDown className={getSortOrderClassName(sortOption.value)} />
+      <span className={styles.dropdownButtonText}>{sortOption?.label}</span>
+    </div>
     <ChevronDown className={isDropdownOpen ? styles.rotate : ''} />
   </Button>
 )

--- a/src/pages/BorrowPage/components/BorrowTable/BorrowTable.module.less
+++ b/src/pages/BorrowPage/components/BorrowTable/BorrowTable.module.less
@@ -171,13 +171,3 @@
     display: none;
   }
 }
-
-.sortDropdown {
-  & > button {
-    min-width: 225px;
-
-    @media (max-width: 640px) {
-      min-width: 185px;
-    }
-  }
-}

--- a/src/pages/BorrowPage/components/BorrowTable/hooks.ts
+++ b/src/pages/BorrowPage/components/BorrowTable/hooks.ts
@@ -223,7 +223,6 @@ export const useBorrowTable = ({ nfts, rawOffers }: UseBorrowTableProps) => {
       sortParams: {
         option: sortOption,
         onChange: setSortOption,
-        className: styles.sortDropdown,
         options: SORT_OPTIONS,
       },
     },

--- a/src/pages/BorrowPage/components/NotConnectedTable/NotConnectedTable.module.less
+++ b/src/pages/BorrowPage/components/NotConnectedTable/NotConnectedTable.module.less
@@ -2,13 +2,3 @@
   color: var(--additional-green-primary-deep);
   font: var(--important-text-md);
 }
-
-.sortDropdown {
-  & > button {
-    min-width: 205px;
-
-    @media (max-width: 640px) {
-      min-width: 180px;
-    }
-  }
-}

--- a/src/pages/BorrowPage/components/NotConnectedTable/hooks.ts
+++ b/src/pages/BorrowPage/components/NotConnectedTable/hooks.ts
@@ -11,8 +11,6 @@ import { useMarketsPreview } from '@banx/pages/LendPage/hooks'
 
 import { DEFAULT_SORT_OPTION } from './constants'
 
-import styles from './NotConnectedTable.module.less'
-
 export const useNotConnectedBorrow = () => {
   const { marketsPreview, isLoading } = useMarketsPreview()
 
@@ -94,7 +92,6 @@ const useSortMarkets = (markets: MarketPreview[]) => {
     sortParams: {
       option: sortOption,
       onChange: setSortOption,
-      className: styles.sortDropdown,
     },
   }
 }

--- a/src/pages/LendPage/components/FilterSection/FilterSection.module.less
+++ b/src/pages/LendPage/components/FilterSection/FilterSection.module.less
@@ -15,13 +15,3 @@
 .searchSelect {
   max-width: 750px;
 }
-
-.sortDropdown {
-  & > button {
-    min-width: 230px;
-
-    @media (max-width: 640px) {
-      min-width: 190px;
-    }
-  }
-}

--- a/src/pages/LendPage/components/FilterSection/FilterSection.tsx
+++ b/src/pages/LendPage/components/FilterSection/FilterSection.tsx
@@ -24,7 +24,7 @@ const FilterSection = <T extends object>({
         collapsed={searchSelectCollapsed}
         onChangeCollapsed={setSearchSelectCollapsed}
       />
-      {searchSelectCollapsed && <SortDropdown {...sortParams} className={styles.sortDropdown} />}
+      {searchSelectCollapsed && <SortDropdown {...sortParams} />}
     </div>
   )
 }

--- a/src/pages/LoansPage/components/LoansActiveTable/LoansActiveTable.module.less
+++ b/src/pages/LoansPage/components/LoansActiveTable/LoansActiveTable.module.less
@@ -162,13 +162,3 @@
     width: 86px;
   }
 }
-
-.sortDropdown {
-  & > button {
-    min-width: 230px;
-
-    @media (max-width: 640px) {
-      min-width: 190px;
-    }
-  }
-}

--- a/src/pages/LoansPage/components/LoansHistoryTable/LoansHistoryTable.module.less
+++ b/src/pages/LoansPage/components/LoansHistoryTable/LoansHistoryTable.module.less
@@ -103,13 +103,3 @@
 .searchSelect {
   max-width: 750px;
 }
-
-.sortDropdown {
-  & > button {
-    min-width: 230px;
-
-    @media (max-width: 640px) {
-      min-width: 190px;
-    }
-  }
-}

--- a/src/pages/LoansPage/components/LoansHistoryTable/hooks/useBorrowerActivity.ts
+++ b/src/pages/LoansPage/components/LoansHistoryTable/hooks/useBorrowerActivity.ts
@@ -9,8 +9,6 @@ import { fetchBorrowerActivity } from '@banx/api/activity'
 
 import { DEFAULT_SORT_OPTION } from '../constants'
 
-import styles from '../LoansHistoryTable.module.less'
-
 const PAGINATION_LIMIT = 15
 
 export const useBorrowerActivity = () => {
@@ -63,7 +61,6 @@ export const useBorrowerActivity = () => {
     sortParams: {
       option: sortOption,
       onChange: setSortOption,
-      className: styles.sortDropdown,
     },
     selectedCollections,
     setSelectedCollections,

--- a/src/pages/OffersPage/components/ActiveOffersTable/ActiveOffersTable.module.less
+++ b/src/pages/OffersPage/components/ActiveOffersTable/ActiveOffersTable.module.less
@@ -62,16 +62,6 @@
   background: var(--additional-red-secondary) !important;
 }
 
-.sortDropdown {
-  & > button {
-    min-width: 230px;
-
-    @media (max-width: 640px) {
-      min-width: 190px;
-    }
-  }
-}
-
 .summary {
   display: flex;
   justify-content: space-between;

--- a/src/pages/OffersPage/components/ActiveOffersTable/hooks/useActiveOffersTable.ts
+++ b/src/pages/OffersPage/components/ActiveOffersTable/hooks/useActiveOffersTable.ts
@@ -62,7 +62,6 @@ export const useActiveOffersTable = () => {
   const sortParams = {
     option: sortOption,
     onChange: setSortOption,
-    className: styles.sortDropdown,
   }
 
   const filteredLoans = useMemo(() => {

--- a/src/pages/OffersPage/components/HistoryOffersTable/HistoryOffersTable.module.less
+++ b/src/pages/OffersPage/components/HistoryOffersTable/HistoryOffersTable.module.less
@@ -96,13 +96,3 @@
 .searchSelect {
   max-width: 750px;
 }
-
-.sortDropdown {
-  & > button {
-    min-width: 210px;
-
-    @media (max-width: 640px) {
-      min-width: 170px;
-    }
-  }
-}

--- a/src/pages/OffersPage/components/HistoryOffersTable/hooks/useLenderActivity.ts
+++ b/src/pages/OffersPage/components/HistoryOffersTable/hooks/useLenderActivity.ts
@@ -9,8 +9,6 @@ import { fetchLenderActivity } from '@banx/api/activity'
 
 import { DEFAULT_SORT_OPTION } from '../constants'
 
-import styles from '../HistoryOffersTable.module.less'
-
 const PAGINATION_LIMIT = 15
 
 export const useLenderActivity = () => {
@@ -63,7 +61,6 @@ export const useLenderActivity = () => {
     sortParams: {
       option: sortOption,
       onChange: setSortOption,
-      className: styles.sortDropdown,
     },
     selectedCollections,
     setSelectedCollections,


### PR DESCRIPTION
## Description

 Fix horizontal gaps and icon size in "sort" button

## Screenshots

### Before 

<img width="277" alt="image" src="https://github.com/frakt-solana/banx-ui/assets/60342317/8dece521-f57a-4074-baae-58c28e69d5a3">

### After

<img width="334" alt="image" src="https://github.com/frakt-solana/banx-ui/assets/60342317/b777f955-8a22-42b5-a3db-3cb9c78bb14f">


## Issue link

https://linear.app/banx-gg/issue/BAN-1294/fe-banx-fix-horizontal-gaps-and-icon-size-in-sort-btn

## Vercel preview

https://banx-ui-git-feature-ban-1294-frakt.vercel.app/lend
