### PR TITLE
BAN-1432: Account fee in active offers search dropdown

### DIFF
--- a/src/pages/OffersPage/components/ActiveOffersTable/hooks/useActiveOffersTable.ts
+++ b/src/pages/OffersPage/components/ActiveOffersTable/hooks/useActiveOffersTable.ts
@@ -36,7 +36,7 @@ export const useActiveOffersTable = () => {
     return map(loansGroupedByCollection, (groupedLoan) => {
       const firstLoanInGroup = first(groupedLoan)
       const { collectionName = '', collectionImage = '' } = firstLoanInGroup?.nft.meta || {}
-      const taken = sumBy(groupedLoan, (nft) => nft.bondTradeTransaction.solAmount)
+      const taken = sumBy(groupedLoan, (nft) => nft.fraktBond.currentPerpetualBorrowed)
 
       return { collectionName, collectionImage, taken }
     })


### PR DESCRIPTION
## Description

Recalculate taken value in dropdown on ActiveOffersTable

## Screenshots

<img width="491" alt="image" src="https://github.com/frakt-solana/banx-ui/assets/60342317/1fc0eca8-9b2e-4ade-b30b-d7be2166a743">


## Issue link

https://linear.app/banx-gg/issue/BAN-1432/fe-banx-account-fee-in-active-offers-search-dropdown

## Vercel preview

https://banx-ui-git-feature-ban-1432-frakt.vercel.app/
