### PR TITLE
BAN-1241: Add everywhere 3 decimals for nfts with floor < 0.1 sol

### DIFF
--- a/src/components/TableComponents/CommonCells.tsx
+++ b/src/components/TableComponents/CommonCells.tsx
@@ -11,9 +11,19 @@ const formatDisplayValue = (
   return initialValue ? `${formattedValue}${unit}` : zeroPlaceholder
 }
 
-export const createSolValueJSX = (initialValue = 0, divider = 1, zeroPlaceholder = '--') => {
-  const formattedValue = (initialValue / divider).toFixed(2)
-  const displayValue = formatDisplayValue(initialValue, formattedValue, '◎', zeroPlaceholder)
+export const createSolValueJSX = (
+  value: number = 0,
+  divider: number = 1,
+  zeroPlaceholder: string = '--',
+  formatValueFunction?: (value: number) => string,
+) => {
+  const valueToFormat = value / divider
+
+  const formattedValue = formatValueFunction
+    ? formatValueFunction(valueToFormat)
+    : valueToFormat.toFixed(2)
+
+  const displayValue = formatDisplayValue(value, formattedValue, '◎', zeroPlaceholder)
 
   return <span className={styles.value}>{displayValue}</span>
 }

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -1,2 +1,6 @@
 export const MOBILE_WIDTH = 768
 export const TABLET_WIDTH = 960
+
+export const DECIMAL_THRESHOLD = 0.1
+export const THREE_DECIMAL_PLACES = 3
+export const TWO_DECIMAL_PLACES = 2

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -4,3 +4,4 @@ export const TABLET_WIDTH = 960
 export const DECIMAL_THRESHOLD = 0.1
 export const THREE_DECIMAL_PLACES = 3
 export const TWO_DECIMAL_PLACES = 2
+export const MIN_DISPLAY_VALUE = 0.001

--- a/src/pages/BorrowPage/components/BorrowTable/columns.tsx
+++ b/src/pages/BorrowPage/components/BorrowTable/columns.tsx
@@ -53,7 +53,7 @@ export const getTableColumns = ({
     {
       key: 'weeklyFee',
       title: <HeaderCell label="Weekly Fee" />,
-      render: (_, nft) => createSolValueJSX(nft.interest, 1e9),
+      render: (_, nft) => createSolValueJSX(nft.interest, 1e9, '--', formatDecimal),
     },
     {
       title: <HeaderCell label="" />,

--- a/src/pages/BorrowPage/components/BorrowTable/columns.tsx
+++ b/src/pages/BorrowPage/components/BorrowTable/columns.tsx
@@ -7,7 +7,7 @@ import {
   createSolValueJSX,
 } from '@banx/components/TableComponents'
 
-import { calcLoanValueWithProtocolFee } from '@banx/utils'
+import { calcLoanValueWithProtocolFee, formatDecimal } from '@banx/utils'
 
 import { SimpleOffer } from '../../types'
 import { BorrowCell } from './BorrowCell'
@@ -42,12 +42,13 @@ export const getTableColumns = ({
     {
       key: 'floorPrice',
       title: <HeaderCell label="Floor" />,
-      render: (_, nft) => createSolValueJSX(nft.nft.nft.collectionFloor, 1e9),
+      render: (_, nft) => createSolValueJSX(nft.nft.nft.collectionFloor, 1e9, '--', formatDecimal),
     },
     {
       key: 'loanValue',
       title: <HeaderCell label="Borrow" />,
-      render: (_, nft) => createSolValueJSX(calcLoanValueWithProtocolFee(nft.loanValue), 1e9),
+      render: (_, nft) =>
+        createSolValueJSX(calcLoanValueWithProtocolFee(nft.loanValue), 1e9, '--', formatDecimal),
     },
     {
       key: 'weeklyFee',

--- a/src/pages/LendPage/components/MarketOverviewInfo/MarketOverviewInfo.tsx
+++ b/src/pages/LendPage/components/MarketOverviewInfo/MarketOverviewInfo.tsx
@@ -6,6 +6,7 @@ import { isFunction } from 'lodash'
 import { StatInfo } from '@banx/components/StatInfo'
 
 import { MarketPreview } from '@banx/api/core'
+import { getDecimalPlaces } from '@banx/utils'
 
 import { ADDITIONAL_MARKET_INFO, MAIN_MARKET_INFO } from './constants'
 
@@ -21,8 +22,9 @@ export const MarketMainInfo: FC<{ market: MarketPreview }> = ({ market }) => {
           {MAIN_MARKET_INFO.map((statInfo) => {
             const { key, ...rest } = statInfo
             const value = market[key as keyof MarketPreview] as string
+            const decimalPlaces = getDecimalPlaces(parseFloat(value) / 1e9)
 
-            return <StatInfo key={key} value={value} {...rest} />
+            return <StatInfo key={key} value={value} {...rest} decimalPlaces={decimalPlaces} />
           })}
         </div>
       </div>

--- a/src/pages/LendPage/components/Offer/Offer.tsx
+++ b/src/pages/LendPage/components/Offer/Offer.tsx
@@ -8,7 +8,7 @@ import { Button } from '@banx/components/Buttons'
 
 import { Pencil } from '@banx/icons'
 import { SyntheticOffer } from '@banx/store'
-import { formatLoansAmount } from '@banx/utils'
+import { formatDecimal, formatLoansAmount } from '@banx/utils'
 
 import styles from './Offer.module.less'
 
@@ -35,7 +35,7 @@ const Offer: FC<OfferProps> = ({ editOffer, offer, isOwnOffer, bestOffer }) => {
     [styles.highlightYour]: connected && offer.publicKey === PUBKEY_PLACEHOLDER,
   })
 
-  const displayLoanValue = ((loanValue || 0) / 1e9)?.toFixed(2)
+  const displayLoanValue = formatDecimal((loanValue || 0) / 1e9)
 
   return (
     <li className={listItemClassName}>

--- a/src/pages/LendPage/components/PlaceOfferTab/components.tsx
+++ b/src/pages/LendPage/components/PlaceOfferTab/components.tsx
@@ -10,7 +10,12 @@ import { useWalletModal } from '@banx/components/WalletModal'
 import { InputErrorMessage } from '@banx/components/inputs'
 
 import { BONDS, WEEKS_IN_YEAR } from '@banx/constants'
-import { HealthColorIncreasing, getColorByPercent, trackPageEvent } from '@banx/utils'
+import {
+  HealthColorIncreasing,
+  getColorByPercent,
+  getDecimalPlaces,
+  trackPageEvent,
+} from '@banx/utils'
 
 import styles from './PlaceOfferTab.module.less'
 
@@ -39,7 +44,12 @@ export const OfferSummary: FC<OfferSummaryProps> = ({
         flexType="row"
         valueType={VALUES_TYPES.PERCENT}
       />
-      <StatInfo label="Offer size" value={offerSize} flexType="row" />
+      <StatInfo
+        label="Offer size"
+        value={offerSize}
+        flexType="row"
+        decimalPlaces={getDecimalPlaces(offerSize)}
+      />
       <StatInfo label="Weekly interest" value={estimatedInterest} flexType="row" />
     </div>
   )

--- a/src/pages/LendPage/components/PlaceOfferTab/components.tsx
+++ b/src/pages/LendPage/components/PlaceOfferTab/components.tsx
@@ -12,8 +12,8 @@ import { InputErrorMessage } from '@banx/components/inputs'
 import { BONDS, WEEKS_IN_YEAR } from '@banx/constants'
 import {
   HealthColorIncreasing,
+  formatDecimal,
   getColorByPercent,
-  getDecimalPlaces,
   trackPageEvent,
 } from '@banx/utils'
 
@@ -35,6 +35,9 @@ export const OfferSummary: FC<OfferSummaryProps> = ({
 
   const colorLTV = getColorByPercent(loanToValuePercent, HealthColorIncreasing)
 
+  const displayEstimatedInterest = estimatedInterest ? formatDecimal(estimatedInterest) : 0
+  const displayOfferSize = offerSize ? formatDecimal(offerSize) : 0
+
   return (
     <div className={styles.offerSummary}>
       <StatInfo
@@ -46,11 +49,16 @@ export const OfferSummary: FC<OfferSummaryProps> = ({
       />
       <StatInfo
         label="Offer size"
-        value={offerSize}
+        value={`${displayOfferSize}◎`}
         flexType="row"
-        decimalPlaces={getDecimalPlaces(offerSize)}
+        valueType={VALUES_TYPES.STRING}
       />
-      <StatInfo label="Weekly interest" value={estimatedInterest} flexType="row" />
+      <StatInfo
+        label="Weekly interest"
+        value={`${displayEstimatedInterest}◎`}
+        valueType={VALUES_TYPES.STRING}
+        flexType="row"
+      />
     </div>
   )
 }

--- a/src/pages/LoansPage/components/LoansActiveTable/TableCells/DebtCell.tsx
+++ b/src/pages/LoansPage/components/LoansActiveTable/TableCells/DebtCell.tsx
@@ -3,7 +3,7 @@ import { FC } from 'react'
 import { createSolValueJSX } from '@banx/components/TableComponents'
 
 import { Loan } from '@banx/api/core'
-import { calculateLoanRepayValue } from '@banx/utils'
+import { calculateLoanRepayValue, formatDecimal } from '@banx/utils'
 
 import styles from '../LoansActiveTable.module.less'
 
@@ -17,7 +17,7 @@ export const DebtCell: FC<DebtCellProps> = ({ loan, isCardView }) => {
 
   const fee = repayValue - loan.bondTradeTransaction.solAmount
 
-  const formattedRepayValue = createSolValueJSX(repayValue, 1e9, '0◎')
+  const formattedRepayValue = createSolValueJSX(repayValue, 1e9, '0◎', formatDecimal)
   const formattedFeeValue = createSolValueJSX(fee, 1e9, '0◎')
 
   return !isCardView ? (

--- a/src/pages/LoansPage/components/LoansActiveTable/TableCells/DebtCell.tsx
+++ b/src/pages/LoansPage/components/LoansActiveTable/TableCells/DebtCell.tsx
@@ -18,7 +18,7 @@ export const DebtCell: FC<DebtCellProps> = ({ loan, isCardView }) => {
   const fee = repayValue - loan.bondTradeTransaction.solAmount
 
   const formattedRepayValue = createSolValueJSX(repayValue, 1e9, '0◎', formatDecimal)
-  const formattedFeeValue = createSolValueJSX(fee, 1e9, '0◎')
+  const formattedFeeValue = createSolValueJSX(fee, 1e9, '0◎', formatDecimal)
 
   return !isCardView ? (
     <div className={styles.debtInfo}>

--- a/src/pages/LoansPage/components/LoansActiveTable/columns.tsx
+++ b/src/pages/LoansPage/components/LoansActiveTable/columns.tsx
@@ -9,6 +9,7 @@ import {
 } from '@banx/components/TableComponents'
 
 import { Loan } from '@banx/api/core'
+import { formatDecimal } from '@banx/utils'
 
 import { ActionsCell, DebtCell, HealthCell, StatusCell } from './TableCells'
 
@@ -50,7 +51,8 @@ export const getTableColumns = ({
     {
       key: 'loanValue',
       title: <HeaderCell label="Borrowed" />,
-      render: (_, { fraktBond }) => createSolValueJSX(fraktBond.borrowedAmount, 1e9),
+      render: (_, { fraktBond }) =>
+        createSolValueJSX(fraktBond.borrowedAmount, 1e9, '--', formatDecimal),
       sorter: true,
     },
     {

--- a/src/pages/LoansPage/components/LoansHistoryTable/TableCells/DebtCell.tsx
+++ b/src/pages/LoansPage/components/LoansHistoryTable/TableCells/DebtCell.tsx
@@ -3,6 +3,7 @@ import { FC } from 'react'
 import { createSolValueJSX } from '@banx/components/TableComponents'
 
 import { BorrowerActivity } from '@banx/api/activity'
+import { formatDecimal } from '@banx/utils'
 
 import styles from '../LoansHistoryTable.module.less'
 
@@ -17,7 +18,7 @@ export const DebtCell: FC<DebtCellrops> = ({ loan, isCardView }) => {
   const lentAmount = currentRemainingLentAmount || borrowed
   const repayValue = lentAmount + interest
 
-  const formattedRepayValue = createSolValueJSX(repayValue, 1e9, '0◎')
+  const formattedRepayValue = createSolValueJSX(repayValue, 1e9, '0◎', formatDecimal)
   const formattedFeeValue = createSolValueJSX(interest, 1e9, '0◎')
 
   return !isCardView ? (

--- a/src/pages/LoansPage/components/LoansHistoryTable/TableCells/RepaidCell.tsx
+++ b/src/pages/LoansPage/components/LoansHistoryTable/TableCells/RepaidCell.tsx
@@ -5,6 +5,7 @@ import { BondTradeTransactionV2State } from 'fbonds-core/lib/fbond-protocol/type
 import { createSolValueJSX } from '@banx/components/TableComponents'
 
 import { BorrowerActivity } from '@banx/api/activity'
+import { formatDecimal } from '@banx/utils'
 
 interface RepaidCellProps {
   loan: BorrowerActivity
@@ -17,5 +18,5 @@ export const RepaidCell: FC<RepaidCellProps> = ({ loan }) => {
     return <>Collateral</>
   }
 
-  return createSolValueJSX(repaid, 1e9)
+  return createSolValueJSX(repaid, 1e9, '--', formatDecimal)
 }

--- a/src/pages/LoansPage/components/LoansHistoryTable/columns.tsx
+++ b/src/pages/LoansPage/components/LoansHistoryTable/columns.tsx
@@ -9,6 +9,7 @@ import {
 } from '@banx/components/TableComponents'
 
 import { BorrowerActivity } from '@banx/api/activity'
+import { formatDecimal } from '@banx/utils'
 
 import { DebtCell, RepaidCell, StatusCell } from './TableCells'
 
@@ -24,7 +25,7 @@ export const getTableColumns = ({ isCardView }: { isCardView: boolean }) => {
     {
       key: 'borrowed',
       title: <HeaderCell label="Borrowed" />,
-      render: (_, { borrowed }) => createSolValueJSX(borrowed, 1e9),
+      render: (_, { borrowed }) => createSolValueJSX(borrowed, 1e9, '--', formatDecimal),
       sorter: true,
     },
     {

--- a/src/pages/OffersPage/components/ActiveOffersTable/TableCells/InterestCell.tsx
+++ b/src/pages/OffersPage/components/ActiveOffersTable/TableCells/InterestCell.tsx
@@ -6,6 +6,7 @@ import moment from 'moment'
 import { createSolValueJSX } from '@banx/components/TableComponents'
 
 import { Loan } from '@banx/api/core'
+import { formatDecimal } from '@banx/utils'
 
 interface InterestCellProps {
   loan: Loan
@@ -23,5 +24,5 @@ export const InterestCell: FC<InterestCellProps> = ({ loan }) => {
     rateBasePoints: amountOfBonds,
   })
 
-  return createSolValueJSX(calculatedInterest + loanValueWithFee, 1e9)
+  return createSolValueJSX(calculatedInterest + loanValueWithFee, 1e9, '--', formatDecimal)
 }

--- a/src/pages/OffersPage/components/ActiveOffersTable/TableCells/LentCell.tsx
+++ b/src/pages/OffersPage/components/ActiveOffersTable/TableCells/LentCell.tsx
@@ -3,7 +3,7 @@ import { FC } from 'react'
 import { createPercentValueJSX, createSolValueJSX } from '@banx/components/TableComponents'
 
 import { Loan } from '@banx/api/core'
-import { HealthColorIncreasing, getColorByPercent } from '@banx/utils'
+import { HealthColorIncreasing, formatDecimal, getColorByPercent } from '@banx/utils'
 
 import styles from '../ActiveOffersTable.module.less'
 
@@ -20,7 +20,7 @@ export const LentCell: FC<LentCellProps> = ({ loan, isCardView }) => {
 
   const ltv = ((solAmount + feeAmount) / collectionFloor) * 100
 
-  const formattedLentValue = createSolValueJSX(currentPerpetualBorrowed, 1e9, '0◎')
+  const formattedLentValue = createSolValueJSX(currentPerpetualBorrowed, 1e9, '0◎', formatDecimal)
 
   return !isCardView ? (
     <div className={styles.lentInfo}>

--- a/src/pages/OffersPage/components/HistoryOffersTable/TableCells/ReceivedCell.tsx
+++ b/src/pages/OffersPage/components/HistoryOffersTable/TableCells/ReceivedCell.tsx
@@ -5,6 +5,7 @@ import { BondTradeTransactionV2State } from 'fbonds-core/lib/fbond-protocol/type
 import { createSolValueJSX } from '@banx/components/TableComponents'
 
 import { LenderActivity } from '@banx/api/activity'
+import { formatDecimal } from '@banx/utils'
 
 interface ReceivedCellProps {
   loan: LenderActivity
@@ -17,5 +18,5 @@ export const ReceivedCell: FC<ReceivedCellProps> = ({ loan }) => {
     return <>Collateral</>
   }
 
-  return createSolValueJSX(received, 1e9)
+  return createSolValueJSX(received, 1e9, '--', formatDecimal)
 }

--- a/src/pages/OffersPage/components/HistoryOffersTable/columns.tsx
+++ b/src/pages/OffersPage/components/HistoryOffersTable/columns.tsx
@@ -31,7 +31,7 @@ export const getTableColumns = () => {
     {
       key: 'interest',
       title: <HeaderCell label="Interest" />,
-      render: (_, loan) => createSolValueJSX(loan.interest, 1e9),
+      render: (_, loan) => createSolValueJSX(loan.interest, 1e9, '--', formatDecimal),
       sorter: true,
     },
     {

--- a/src/pages/OffersPage/components/HistoryOffersTable/columns.tsx
+++ b/src/pages/OffersPage/components/HistoryOffersTable/columns.tsx
@@ -9,6 +9,7 @@ import {
 } from '@banx/components/TableComponents'
 
 import { LenderActivity } from '@banx/api/activity'
+import { formatDecimal } from '@banx/utils'
 
 import { APRCell, ReceivedCell, StatusCell } from './TableCells'
 
@@ -24,7 +25,7 @@ export const getTableColumns = () => {
     {
       key: 'lent',
       title: <HeaderCell label="Lent" />,
-      render: (_, loan) => createSolValueJSX(loan.lent, 1e9),
+      render: (_, loan) => createSolValueJSX(loan.lent, 1e9, '--', formatDecimal),
       sorter: true,
     },
     {

--- a/src/pages/OffersPage/components/PendingOffersTable/TableCells/InterestCell.tsx
+++ b/src/pages/OffersPage/components/PendingOffersTable/TableCells/InterestCell.tsx
@@ -2,6 +2,8 @@ import { FC } from 'react'
 
 import { createSolValueJSX } from '@banx/components/TableComponents'
 
+import { formatDecimal } from '@banx/utils'
+
 import { TableUserOfferData } from '../helpers'
 
 interface InterestCellProps {
@@ -16,5 +18,5 @@ export const InterestCell: FC<InterestCellProps> = ({ offer }) => {
   const weeklyAprPercentage = apr / WEEKS_IN_YEAR
   const estimatedInterest = (size * weeklyAprPercentage) / 100
 
-  return createSolValueJSX(estimatedInterest, 1e9)
+  return createSolValueJSX(estimatedInterest, 1e9, '--', formatDecimal)
 }

--- a/src/pages/OffersPage/components/PendingOffersTable/TableCells/OfferCell.tsx
+++ b/src/pages/OffersPage/components/PendingOffersTable/TableCells/OfferCell.tsx
@@ -2,7 +2,7 @@ import { FC } from 'react'
 
 import { createPercentValueJSX, createSolValueJSX } from '@banx/components/TableComponents'
 
-import { HealthColorIncreasing, getColorByPercent } from '@banx/utils'
+import { HealthColorIncreasing, formatDecimal, getColorByPercent } from '@banx/utils'
 
 import { TableUserOfferData } from '../helpers'
 
@@ -18,7 +18,7 @@ export const OfferCell: FC<OfferCellProps> = ({ offer, isCardView }) => {
 
   const ltv = (loanValue / collectionFloor) * 100
 
-  const formattedLoanValue = createSolValueJSX(loanValue, 1e9)
+  const formattedLoanValue = createSolValueJSX(loanValue, 1e9, '--', formatDecimal)
 
   return !isCardView ? (
     <div className={styles.offerCell}>

--- a/src/pages/OffersPage/components/PendingOffersTable/columns.tsx
+++ b/src/pages/OffersPage/components/PendingOffersTable/columns.tsx
@@ -7,7 +7,7 @@ import {
   createSolValueJSX,
 } from '@banx/components/TableComponents'
 
-import { formatLoansAmount } from '@banx/utils'
+import { formatDecimal, formatLoansAmount } from '@banx/utils'
 
 import { APRCell, ActionsCell, InterestCell, OfferCell } from './TableCells'
 import { TableUserOfferData } from './helpers'
@@ -34,7 +34,7 @@ export const getTableColumns = ({ isCardView }: { isCardView: boolean }) => {
     {
       key: 'size',
       title: <HeaderCell label="Size" />,
-      render: (_, { size }) => createSolValueJSX(size, 1e9),
+      render: (_, { size }) => createSolValueJSX(size, 1e9, '--', formatDecimal),
     },
     {
       key: 'interest',

--- a/src/pages/RefinancePage/components/RefinanceTable/TableCells/DebtCell.tsx
+++ b/src/pages/RefinancePage/components/RefinanceTable/TableCells/DebtCell.tsx
@@ -6,6 +6,7 @@ import moment from 'moment'
 import { createSolValueJSX } from '@banx/components/TableComponents'
 
 import { Loan } from '@banx/api/core'
+import { formatDecimal } from '@banx/utils'
 
 export const DebtCell: FC<{ loan: Loan }> = ({ loan }) => {
   const { solAmount, soldAt, feeAmount, amountOfBonds } = loan.bondTradeTransaction || {}
@@ -19,5 +20,5 @@ export const DebtCell: FC<{ loan: Loan }> = ({ loan }) => {
 
   const repayValue = solAmount + calculatedInterest + feeAmount
 
-  return createSolValueJSX(repayValue, 1e9)
+  return createSolValueJSX(repayValue, 1e9, '--', formatDecimal)
 }

--- a/src/pages/RefinancePage/components/RefinanceTable/columns.tsx
+++ b/src/pages/RefinancePage/components/RefinanceTable/columns.tsx
@@ -10,7 +10,7 @@ import Timer from '@banx/components/Timer/Timer'
 
 import { Loan } from '@banx/api/core'
 import { WEEKS_IN_YEAR } from '@banx/constants'
-import { calculateLoanRepayValue } from '@banx/utils'
+import { calculateLoanRepayValue, formatDecimal } from '@banx/utils'
 
 import { APRCell, APRIncreaseCell, DebtCell, RefinanceCell } from './TableCells'
 import { SECONDS_IN_72_HOURS } from './constants'
@@ -42,7 +42,7 @@ export const getTableColumns = ({
     {
       key: 'floorPrice',
       title: <HeaderCell label="Floor" />,
-      render: (_, loan) => createSolValueJSX(loan.nft.collectionFloor, 1e9),
+      render: (_, loan) => createSolValueJSX(loan.nft.collectionFloor, 1e9, '--', formatDecimal),
     },
     {
       key: 'repayValue',

--- a/src/pages/RefinancePage/components/RefinanceTable/columns.tsx
+++ b/src/pages/RefinancePage/components/RefinanceTable/columns.tsx
@@ -52,7 +52,7 @@ export const getTableColumns = ({
     {
       key: 'interest',
       title: <HeaderCell label="Weekly interest" />,
-      render: (_, loan) => createSolValueJSX(calcWeeklyInterestFee(loan)),
+      render: (_, loan) => createSolValueJSX(calcWeeklyInterestFee(loan), 1, '--', formatDecimal),
     },
     {
       key: 'apy',

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,6 +1,12 @@
 import { flatMap, map, reduce, uniq } from 'lodash'
 
-import { BONDS, WEEKS_IN_YEAR } from '@banx/constants'
+import {
+  BONDS,
+  DECIMAL_THRESHOLD,
+  THREE_DECIMAL_PLACES,
+  TWO_DECIMAL_PLACES,
+  WEEKS_IN_YEAR,
+} from '@banx/constants'
 
 // shorten the checksummed version of the input address to have 4 characters at start and end
 export const shortenAddress = (address: string, chars = 4): string => {
@@ -19,8 +25,18 @@ export const convertAprToApy = (apr: number) => {
   return Math.round(apy * 100)
 }
 
+export const getDecimalPlaces = (value: number | string) => {
+  const numericValue = typeof value === 'string' ? parseFloat(value) : value
+
+  if (!numericValue) return TWO_DECIMAL_PLACES
+
+  return numericValue < DECIMAL_THRESHOLD ? THREE_DECIMAL_PLACES : TWO_DECIMAL_PLACES
+}
+
 export const formatDecimal = (value: number) => {
-  return value < 0.1 ? value.toFixed(3) : value?.toFixed(2)
+  const numericValue = typeof value === 'string' ? parseFloat(value) : value
+  const decimalPlaces = getDecimalPlaces(numericValue)
+  return numericValue.toFixed(decimalPlaces)
 }
 
 export const formatNumbersWithCommas = (value: number | string) =>

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -19,6 +19,10 @@ export const convertAprToApy = (apr: number) => {
   return Math.round(apy * 100)
 }
 
+export const formatDecimal = (value: number) => {
+  return value < 0.1 ? value.toFixed(3) : value?.toFixed(2)
+}
+
 export const formatNumbersWithCommas = (value: number | string) =>
   value.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
 

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -3,6 +3,7 @@ import { flatMap, map, reduce, uniq } from 'lodash'
 import {
   BONDS,
   DECIMAL_THRESHOLD,
+  MIN_DISPLAY_VALUE,
   THREE_DECIMAL_PLACES,
   TWO_DECIMAL_PLACES,
   WEEKS_IN_YEAR,
@@ -35,6 +36,9 @@ export const getDecimalPlaces = (value: number | string) => {
 
 export const formatDecimal = (value: number) => {
   const numericValue = typeof value === 'string' ? parseFloat(value) : value
+
+  if (numericValue < MIN_DISPLAY_VALUE) return `<${MIN_DISPLAY_VALUE}`
+
   const decimalPlaces = getDecimalPlaces(numericValue)
   return numericValue.toFixed(decimalPlaces)
 }


### PR DESCRIPTION
## Description

<!-- Describe your changes here -->

## Screenshots

<!-- If applicable -->

## Issue link

https://linear.app/banx-gg/issue/BAN-1241/fe-banx-add-everywhere-3-decimals-for-nfts-with-floor-01-sol

## Vercel preview

https://banx-ui-git-feature-ban-1241-frakt.vercel.app/
