### PR TITLE
BAN-910: Add player points and partner points to refinance page

### DIFF
--- a/src/api/core/types.ts
+++ b/src/api/core/types.ts
@@ -79,6 +79,8 @@ export const NFTSchema = z.object({
     name: z.string(),
     collectionName: z.string(),
     collectionImage: z.string(),
+    partnerPoints: z.number().optional(),
+    playerPoints: z.number().optional(),
   }),
   compression: z
     .object({

--- a/src/components/TableComponents/CollaterallCell.tsx
+++ b/src/components/TableComponents/CollaterallCell.tsx
@@ -7,6 +7,7 @@ import { PlaceholderPFP } from '@banx/icons'
 import { ViewState, useTableView } from '@banx/store'
 
 import Checkbox from '../Checkbox'
+import Tooltip from '../Tooltip/Tooltip'
 
 import styles from './TableCells.module.less'
 
@@ -82,8 +83,10 @@ interface PointsBanxBadgeProps {
 
 const PointsBanxBadge: FC<PointsBanxBadgeProps> = ({ playerPoints, partnerPoints }) => {
   return (
-    <div className={styles.badge}>
-      {partnerPoints}/{playerPoints}
-    </div>
+    <Tooltip title="Partner Points / Player Points">
+      <div className={styles.badge}>
+        {partnerPoints}/{playerPoints}
+      </div>
+    </Tooltip>
   )
 }

--- a/src/components/TableComponents/CollaterallCell.tsx
+++ b/src/components/TableComponents/CollaterallCell.tsx
@@ -15,6 +15,11 @@ interface NftInfoCellProps {
   nftImage: string
   selected?: boolean
   onCheckboxClick?: () => void
+
+  banxBadgeProps?: {
+    partnerPoints: number
+    playerPoints: number
+  }
 }
 
 export const NftInfoCell: FC<NftInfoCellProps> = ({
@@ -22,6 +27,7 @@ export const NftInfoCell: FC<NftInfoCellProps> = ({
   nftImage,
   onCheckboxClick,
   selected = false,
+  banxBadgeProps,
 }) => {
   const { viewState } = useTableView()
   const isCardView = viewState === ViewState.CARD
@@ -29,12 +35,15 @@ export const NftInfoCell: FC<NftInfoCellProps> = ({
   const [nftCollectionName, nftNumber] = nftName.split('#')
   const displayNftNumber = nftNumber ? `#${nftNumber}` : ''
 
+  const showPointsBadge = !!banxBadgeProps?.partnerPoints
+
   return (
     <div className={styles.nftInfo}>
       {onCheckboxClick && !isCardView && (
         <Checkbox className={styles.checkbox} onChange={onCheckboxClick} checked={selected} />
       )}
       <div className={styles.nftImageWrapper}>
+        {showPointsBadge && <PointsBanxBadge {...banxBadgeProps} />}
         <NftImage nftImage={nftImage} />
         {selected && isCardView && <div className={styles.selectedCollectionOverlay} />}
       </div>
@@ -63,5 +72,18 @@ const NftImage: FC<NftImageProps> = ({ nftImage }) => {
     <img src={nftImage} className={styles.nftImage} />
   ) : (
     <PlaceholderPFP className={styles.nftPlaceholderIcon} />
+  )
+}
+
+interface PointsBanxBadgeProps {
+  playerPoints: number
+  partnerPoints: number
+}
+
+const PointsBanxBadge: FC<PointsBanxBadgeProps> = ({ playerPoints, partnerPoints }) => {
+  return (
+    <div className={styles.badge}>
+      {partnerPoints}/{playerPoints}
+    </div>
   )
 }

--- a/src/components/TableComponents/TableCells.module.less
+++ b/src/components/TableComponents/TableCells.module.less
@@ -2,7 +2,6 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  overflow-x: hidden;
 }
 .nftImageWrapper {
   display: flex;
@@ -66,7 +65,7 @@
 }
 
 .nftNumber {
-  font: var(--body-text-xs);
+  font: var(--body-text-sm);
 }
 
 .checkbox {
@@ -90,4 +89,18 @@
     color: var(--content-primary);
     text-decoration: none;
   }
+}
+
+.badge {
+  background: var(--additional-green-secondary);
+  border: 0.5px solid var(--additional-green-primary-deep);
+  border-radius: 100px;
+  color: var(--additional-green-primary-deep);
+  font: var(--body-text-xs);
+  padding: 0 6px;
+  position: absolute;
+  left: -8px;
+  top: -8px;
+  white-space: nowrap;
+  z-index: 10;
 }

--- a/src/pages/RefinancePage/components/RefinanceTable/columns.tsx
+++ b/src/pages/RefinancePage/components/RefinanceTable/columns.tsx
@@ -38,7 +38,7 @@ export const getTableColumns = ({
           nftImage={loan.nft.meta.imageUrl}
           banxBadgeProps={{
             partnerPoints: loan.nft.meta.partnerPoints || 0,
-            playerPoints: loan.nft.meta.partnerPoints || 0,
+            playerPoints: loan.nft.meta.playerPoints || 0,
           }}
         />
       ),

--- a/src/pages/RefinancePage/components/RefinanceTable/columns.tsx
+++ b/src/pages/RefinancePage/components/RefinanceTable/columns.tsx
@@ -36,6 +36,10 @@ export const getTableColumns = ({
           onCheckboxClick={() => onSelectLoan(loan)}
           nftName={loan.nft.meta.name}
           nftImage={loan.nft.meta.imageUrl}
+          banxBadgeProps={{
+            partnerPoints: loan.nft.meta.partnerPoints || 0,
+            playerPoints: loan.nft.meta.partnerPoints || 0,
+          }}
         />
       ),
     },


### PR DESCRIPTION
## Description

Add player points and partner points to refinance page

## Screenshots

<img width="1260" alt="image" src="https://github.com/frakt-solana/banx-ui/assets/60342317/a9d93ca0-5e70-47ee-b06a-75fe7e909af7">


## Issue link

https://linear.app/banx-gg/issue/BAN-910/fe-banx-display-partnerplayer-points-on-auction-page

## Vercel preview

[banx-ui-git-feature-ban-910-frakt.vercel.app](https://banx-ui-git-feature-ban-910-frakt.vercel.app/)
