### PR TITLE
BAN-1455: Loan status tooltip rewording

### DIFF
--- a/src/pages/LendPage/components/ActivityTable/columns.tsx
+++ b/src/pages/LendPage/components/ActivityTable/columns.tsx
@@ -38,7 +38,7 @@ export const getTableColumns = () => {
       title: (
         <HeaderCell
           label="Loan status"
-          tooltipText="Current status and remaining duration of a loan"
+          tooltipText="Current status and duration of the loan that has been passed"
         />
       ),
       render: (_, loan) => <StatusCell loan={loan} />,

--- a/src/pages/LoansPage/components/LoansActiveTable/columns.tsx
+++ b/src/pages/LoansPage/components/LoansActiveTable/columns.tsx
@@ -77,7 +77,7 @@ export const getTableColumns = ({
       title: (
         <HeaderCell
           label="Loan status"
-          tooltipText="Current status and remaining duration of a loan"
+          tooltipText="Current status and duration of the loan that has been passed"
         />
       ),
       render: (_, loan) => <StatusCell loan={loan} isCardView={isCardView} />,

--- a/src/pages/OffersPage/components/ActiveOffersTable/columns.tsx
+++ b/src/pages/OffersPage/components/ActiveOffersTable/columns.tsx
@@ -46,7 +46,7 @@ export const getTableColumns = ({ isCardView }: GetTableColumns) => {
       title: (
         <HeaderCell
           label="Loan status"
-          tooltipText="Current status and remaining duration of a loan"
+          tooltipText="Current status and duration of the loan that has been passed"
         />
       ),
       render: (_, loan) => <StatusCell loan={loan} isCardView={isCardView} />,


### PR DESCRIPTION
## Description

 Loan status tooltip rewording

## Screenshots

<img width="310" alt="image" src="https://github.com/frakt-solana/banx-ui/assets/60342317/0b4582cc-dc1d-4b9d-99a5-9dad0fb41727">

## Issue link

https://linear.app/banx-gg/issue/BAN-1455/fe-banx-loan-status-tooltip-rewording

## Vercel preview

https://banx-ui-git-feature-ban-1455-frakt.vercel.app/
