### PR TITLE
BAN-1454: Move and recalculate LTV on My offers -> Active page

### DIFF
--- a/src/pages/OffersPage/components/ActiveOffersTable/TableCells/InterestCell.tsx
+++ b/src/pages/OffersPage/components/ActiveOffersTable/TableCells/InterestCell.tsx
@@ -3,26 +3,56 @@ import { FC } from 'react'
 import { calculateCurrentInterestSolPure } from 'fbonds-core/lib/fbond-protocol/functions/perpetual'
 import moment from 'moment'
 
-import { createSolValueJSX } from '@banx/components/TableComponents'
+import { createPercentValueJSX, createSolValueJSX } from '@banx/components/TableComponents'
 
 import { Loan } from '@banx/api/core'
-import { formatDecimal } from '@banx/utils'
+import { HealthColorIncreasing, formatDecimal, getColorByPercent } from '@banx/utils'
+
+import styles from '../ActiveOffersTable.module.less'
 
 interface InterestCellProps {
   loan: Loan
+  isCardView: boolean
 }
 
-export const InterestCell: FC<InterestCellProps> = ({ loan }) => {
+export const InterestCell: FC<InterestCellProps> = ({ loan, isCardView }) => {
   const { solAmount, feeAmount, amountOfBonds, soldAt } = loan.bondTradeTransaction || {}
 
-  const loanValueWithFee = solAmount + feeAmount
+  const totalLoanValue = solAmount + feeAmount
+  const collectionFloor = loan.nft.collectionFloor
 
-  const calculatedInterest = calculateCurrentInterestSolPure({
-    loanValue: loanValueWithFee,
+  const interestParameters = {
+    loanValue: totalLoanValue,
     startTime: soldAt,
     currentTime: moment().unix(),
     rateBasePoints: amountOfBonds,
-  })
+  }
 
-  return createSolValueJSX(calculatedInterest + loanValueWithFee, 1e9, '--', formatDecimal)
+  const currentInterest = calculateCurrentInterestSolPure(interestParameters)
+  const totalClaimValue = currentInterest + totalLoanValue
+
+  const formattedClaimValue = createSolValueJSX(totalClaimValue, 1e9, '--', formatDecimal)
+
+  const loanToValueRatio = (totalClaimValue / collectionFloor) * 100
+
+  return !isCardView ? (
+    <div className={styles.lentInfo}>
+      <span>{formattedClaimValue}</span>
+      {createLtvValueJSX(loanToValueRatio)}
+    </div>
+  ) : (
+    <span>
+      {formattedClaimValue} ({createLtvValueJSX(loanToValueRatio)})
+    </span>
+  )
+}
+
+const createLtvValueJSX = (ltv: number) => {
+  const colorLTV = getColorByPercent(ltv, HealthColorIncreasing)
+
+  return (
+    <span className={styles.lentInfoSubtitle} style={{ color: colorLTV }}>
+      {createPercentValueJSX(ltv)} LTV
+    </span>
+  )
 }

--- a/src/pages/OffersPage/components/ActiveOffersTable/TableCells/LentCell.tsx
+++ b/src/pages/OffersPage/components/ActiveOffersTable/TableCells/LentCell.tsx
@@ -7,7 +7,6 @@ import { formatDecimal } from '@banx/utils'
 
 interface LentCellProps {
   loan: Loan
-  isCardView: boolean
 }
 
 export const LentCell: FC<LentCellProps> = ({ loan }) => {

--- a/src/pages/OffersPage/components/ActiveOffersTable/TableCells/LentCell.tsx
+++ b/src/pages/OffersPage/components/ActiveOffersTable/TableCells/LentCell.tsx
@@ -1,45 +1,19 @@
 import { FC } from 'react'
 
-import { createPercentValueJSX, createSolValueJSX } from '@banx/components/TableComponents'
+import { createSolValueJSX } from '@banx/components/TableComponents'
 
 import { Loan } from '@banx/api/core'
-import { HealthColorIncreasing, formatDecimal, getColorByPercent } from '@banx/utils'
-
-import styles from '../ActiveOffersTable.module.less'
+import { formatDecimal } from '@banx/utils'
 
 interface LentCellProps {
   loan: Loan
   isCardView: boolean
 }
 
-export const LentCell: FC<LentCellProps> = ({ loan, isCardView }) => {
-  const { solAmount, feeAmount } = loan.bondTradeTransaction || {}
+export const LentCell: FC<LentCellProps> = ({ loan }) => {
   const { currentPerpetualBorrowed } = loan.fraktBond || {}
-
-  const collectionFloor = loan.nft.collectionFloor
-
-  const ltv = ((solAmount + feeAmount) / collectionFloor) * 100
 
   const formattedLentValue = createSolValueJSX(currentPerpetualBorrowed, 1e9, '0◎', formatDecimal)
 
-  return !isCardView ? (
-    <div className={styles.lentInfo}>
-      <span>{formattedLentValue}</span>
-      {createLtvValueJSX(ltv)}
-    </div>
-  ) : (
-    <span>
-      {formattedLentValue} ({createLtvValueJSX(ltv)})
-    </span>
-  )
-}
-
-const createLtvValueJSX = (ltv: number) => {
-  const colorLTV = getColorByPercent(ltv, HealthColorIncreasing)
-
-  return (
-    <span className={styles.lentInfoSubtitle} style={{ color: colorLTV }}>
-      {createPercentValueJSX(ltv)} LTV
-    </span>
-  )
+  return formattedLentValue
 }

--- a/src/pages/OffersPage/components/ActiveOffersTable/columns.tsx
+++ b/src/pages/OffersPage/components/ActiveOffersTable/columns.tsx
@@ -22,7 +22,7 @@ export const getTableColumns = ({ isCardView }: GetTableColumns) => {
     {
       key: 'lent',
       title: <HeaderCell label="Lent" />,
-      render: (_, loan) => <LentCell loan={loan} isCardView={isCardView} />,
+      render: (_, loan) => <LentCell loan={loan} />,
       sorter: true,
     },
     {

--- a/src/pages/OffersPage/components/ActiveOffersTable/columns.tsx
+++ b/src/pages/OffersPage/components/ActiveOffersTable/columns.tsx
@@ -33,7 +33,7 @@ export const getTableColumns = ({ isCardView }: GetTableColumns) => {
           tooltipText="Sum of lent amount and accrued interest to date"
         />
       ),
-      render: (_, loan) => <InterestCell loan={loan} />,
+      render: (_, loan) => <InterestCell loan={loan} isCardView={isCardView} />,
     },
     {
       key: 'apy',


### PR DESCRIPTION
## Description

Move and recalculate LTV on My offers -> Active page

## Screenshots

<img width="1276" alt="image" src="https://github.com/frakt-solana/banx-ui/assets/60342317/82a88766-323d-4aad-a457-02747998f593">

## Issue link

https://linear.app/banx-gg/issue/BAN-1454/fe-banx-move-and-recalculate-ltv-on-my-offers-active-page

## Vercel preview

https://banx-ui-git-feature-ban-1454-frakt.vercel.app/
