### PR TITLE
BAN-1491: Replace "select all" btn with slider on Refinance page

### DIFF
--- a/src/components/Slider/Slider.module.less
+++ b/src/components/Slider/Slider.module.less
@@ -8,6 +8,10 @@
   gap: 8px;
   min-width: 200px;
   width: 100%;
+
+  @media (max-width: 960px) {
+    min-width: unset;
+  }
 }
 
 .counterSlider {

--- a/src/pages/RefinancePage/components/RefinanceTable/RefinanceTable.module.less
+++ b/src/pages/RefinancePage/components/RefinanceTable/RefinanceTable.module.less
@@ -136,7 +136,7 @@
     width: 100%;
 
     button {
-      min-width: unset;
+      min-width: 176px;
     }
   }
 }

--- a/src/pages/RefinancePage/components/RefinanceTable/RefinanceTable.module.less
+++ b/src/pages/RefinancePage/components/RefinanceTable/RefinanceTable.module.less
@@ -86,7 +86,7 @@
   font: var(--table-header-md);
   color: var(--content-secondary);
   text-transform: uppercase;
-  max-width: 120px;
+  max-width: 100px;
 
   @media (max-width: 960px) {
     max-width: unset;
@@ -100,17 +100,20 @@
 
 .statsContainer {
   display: flex;
-  justify-content: flex-end;
-  gap: 112px;
-  padding-right: 16px;
+  justify-content: space-around;
   flex-grow: 1;
 
-  @media (max-width: 960px) {
+  & > div {
+    align-items: end;
+  }
+
+  @media (max-width: 1240px) {
     width: 100%;
     align-items: space-between;
-    justify-content: space-around;
-    gap: unset;
-    padding-right: unset;
+
+    & > div {
+      align-items: center;
+    }
   }
 
   @media (max-width: 640px) {
@@ -118,42 +121,13 @@
   }
 }
 
-.stats {
-  p:first-child {
-    color: var(--content-secondary);
-    font: var(--table-header-md);
-    text-transform: uppercase;
-  }
-
-  p:last-child {
-    color: var(--content-primary);
-    font: var(--body-text-md);
-    text-align: right;
-  }
-
-  @media (max-width: 1240px) {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-  }
-
-  @media (max-width: 640px) {
-    p:first-child {
-      font: var(--table-header-sm);
-    }
-
-    p:last-child {
-      font: var(--body-text-sm);
-    }
-  }
-}
-
 .summaryBtns {
   display: flex;
-  gap: 8px;
+  align-items: center;
+  gap: 16px;
 
   button {
-    min-width: 170px;
+    min-width: 190px;
   }
 
   @media (max-width: 960px) {
@@ -164,21 +138,5 @@
     button {
       min-width: unset;
     }
-  }
-}
-
-.borrowButton {
-  width: 104px;
-}
-
-.selectButtonText {
-  @media (max-width: 1240px) {
-    display: none;
-  }
-}
-
-.selectButtonMobileText {
-  @media (min-width: 1241px) {
-    display: none;
   }
 }

--- a/src/pages/RefinancePage/components/RefinanceTable/RefinanceTable.tsx
+++ b/src/pages/RefinancePage/components/RefinanceTable/RefinanceTable.tsx
@@ -57,8 +57,9 @@ export const RefinanceTable = () => {
         fetchMoreTrigger={fetchMoreTrigger}
       />
       <Summary
+        loans={loans}
         selectedLoans={selectedLoans}
-        onSelectAllLoans={() => onSelectAllLoans(loans)}
+        onSelectLoans={onSelectAllLoans}
         onDeselectAllLoans={onDeselectAllLoans}
       />
     </div>

--- a/src/pages/RefinancePage/components/RefinanceTable/RefinanceTable.tsx
+++ b/src/pages/RefinancePage/components/RefinanceTable/RefinanceTable.tsx
@@ -18,7 +18,7 @@ export const RefinanceTable = () => {
   const { loans, sortViewParams, loading, showEmptyList } = useRefinanceTable()
   const navigate = useNavigate()
 
-  const { selectedLoans, onSelectLoan, findSelectedLoan, onSelectAllLoans, onDeselectAllLoans } =
+  const { selectedLoans, onSelectLoan, findSelectedLoan, onSelectLoans, onDeselectAllLoans } =
     useLoansState()
 
   const { viewState } = useTableView()
@@ -59,7 +59,7 @@ export const RefinanceTable = () => {
       <Summary
         loans={loans}
         selectedLoans={selectedLoans}
-        onSelectLoans={onSelectAllLoans}
+        onSelectLoans={onSelectLoans}
         onDeselectAllLoans={onDeselectAllLoans}
       />
     </div>

--- a/src/pages/RefinancePage/components/RefinanceTable/TableCells/RefinanceCell.tsx
+++ b/src/pages/RefinancePage/components/RefinanceTable/TableCells/RefinanceCell.tsx
@@ -28,9 +28,10 @@ import styles from '../RefinanceTable.module.less'
 interface RefinanceCellProps {
   loan: Loan
   isCardView: boolean
+  disabledAction: boolean
 }
 
-export const RefinanceCell: FC<RefinanceCellProps> = ({ loan, isCardView }) => {
+export const RefinanceCell: FC<RefinanceCellProps> = ({ loan, isCardView, disabledAction }) => {
   const { connected } = useWallet()
   const { toggleVisibility } = useWalletModal()
 
@@ -49,7 +50,7 @@ export const RefinanceCell: FC<RefinanceCellProps> = ({ loan, isCardView }) => {
 
   return (
     <div className={classNames(styles.refinanceCell, { [styles.cardView]: isCardView })}>
-      <Button onClick={onClickHandler} size={buttonSize}>
+      <Button onClick={onClickHandler} size={buttonSize} disabled={disabledAction}>
         Refinance
       </Button>
       <SolanaFMLink

--- a/src/pages/RefinancePage/components/RefinanceTable/columns.tsx
+++ b/src/pages/RefinancePage/components/RefinanceTable/columns.tsx
@@ -79,7 +79,13 @@ export const getTableColumns = ({
     },
     {
       title: <HeaderCell label="" />,
-      render: (_, loan) => <RefinanceCell loan={loan} isCardView={isCardView} />,
+      render: (_, loan) => (
+        <RefinanceCell
+          loan={loan}
+          isCardView={isCardView}
+          disabledAction={!!findSelectedLoan(loan.publicKey)}
+        />
+      ),
     },
   ]
 

--- a/src/pages/RefinancePage/components/RefinanceTable/hooks/useRefinanceTable.ts
+++ b/src/pages/RefinancePage/components/RefinanceTable/hooks/useRefinanceTable.ts
@@ -71,7 +71,7 @@ type LoansState = {
   selectedLoans: Loan[]
   findSelectedLoan: (loanPubkey: string) => Loan | undefined
   onSelectLoan: (loan: Loan) => void
-  onSelectAllLoans: (loans: Loan[]) => void
+  onSelectLoans: (loans: Loan[]) => void
   onDeselectAllLoans: () => void
   deselectLoan: (loanPubkey: string) => void
 }
@@ -92,7 +92,7 @@ export const useLoansState = create<LoansState>((set, get) => ({
       }
       return { selectedLoans: [...state.selectedLoans, loan] }
     }),
-  onSelectAllLoans: (loans) => set({ selectedLoans: [...loans] }),
+  onSelectLoans: (loans) => set({ selectedLoans: [...loans] }),
   onDeselectAllLoans: () => set({ selectedLoans: [] }),
   deselectLoan: (loanPubkey) =>
     set((state) => ({


### PR DESCRIPTION
## Description

Replace "select all" btn with slider on Refinance page

## Screenshots

<img width="1470" alt="image" src="https://github.com/frakt-solana/banx-ui/assets/60342317/40e55ae3-2924-4d06-9da3-b3d598323356">


## Issue link

https://linear.app/banx-gg/issue/BAN-1491/fe-banx-replace-select-all-btn-with-slider-on-refinance-page

## Vercel preview

https://banx-ui-git-feature-ban-1491-frakt.vercel.app/
