### PR TITLE
BAN-1529: Add sorting by LTV on active offers page

### DIFF
--- a/src/pages/LendPage/components/ActivityTable/columns.tsx
+++ b/src/pages/LendPage/components/ActivityTable/columns.tsx
@@ -42,7 +42,7 @@ export const getTableColumns = () => {
       key: 'status',
       title: (
         <HeaderCell
-          label="Loan status"
+          label="Status"
           tooltipText="Current status and duration of the loan that has been passed"
         />
       ),

--- a/src/pages/LoansPage/components/LoansHistoryTable/columns.tsx
+++ b/src/pages/LoansPage/components/LoansHistoryTable/columns.tsx
@@ -40,7 +40,7 @@ export const getTableColumns = ({ isCardView }: { isCardView: boolean }) => {
     },
     {
       key: 'status',
-      title: <HeaderCell label="Loan status" />,
+      title: <HeaderCell label="Status" />,
       render: (loan) => <StatusCell loan={loan} />,
     },
     {

--- a/src/pages/OffersPage/components/ActiveOffersTable/Summary.tsx
+++ b/src/pages/OffersPage/components/ActiveOffersTable/Summary.tsx
@@ -41,8 +41,7 @@ export const Summary: FC<SummaryProps> = ({
   const totalTerminateLent = useMemo(() => {
     return sumBy(
       loansToTerminate,
-      ({ bondTradeTransaction }) =>
-        bondTradeTransaction.solAmount + bondTradeTransaction.feeAmount,
+      ({ bondTradeTransaction }) => bondTradeTransaction.solAmount + bondTradeTransaction.feeAmount,
     )
   }, [loansToTerminate])
 

--- a/src/pages/OffersPage/components/ActiveOffersTable/columns.tsx
+++ b/src/pages/OffersPage/components/ActiveOffersTable/columns.tsx
@@ -29,7 +29,6 @@ export const getTableColumns = ({ isCardView }: GetTableColumns) => {
       key: 'lent',
       title: <HeaderCell label="Lent" />,
       render: (loan) => <LentCell loan={loan} />,
-      sorter: true,
     },
     {
       key: 'interest',
@@ -45,18 +44,16 @@ export const getTableColumns = ({ isCardView }: GetTableColumns) => {
       key: 'apy',
       title: <HeaderCell label="APY" />,
       render: (loan) => <APRCell loan={loan} />,
-      sorter: true,
     },
     {
       key: 'status',
       title: (
         <HeaderCell
-          label="Loan status"
+          label="Status"
           tooltipText="Current status and duration of the loan that has been passed"
         />
       ),
       render: (loan) => <StatusCell loan={loan} isCardView={isCardView} />,
-      sorter: true,
     },
     {
       key: 'actionsCell',

--- a/src/pages/OffersPage/components/ActiveOffersTable/constants.ts
+++ b/src/pages/OffersPage/components/ActiveOffersTable/constants.ts
@@ -1,7 +1,14 @@
 import { SortOption } from '@banx/components/SortDropdown'
 
+export const SORT_OPTIONS = [
+  { label: 'Lent', value: 'lent' },
+  { label: 'LTV', value: 'ltv' },
+  { label: 'APY', value: 'apy' },
+  { label: 'Status', value: 'status' },
+]
+
 export const DEFAULT_SORT_OPTION: SortOption = {
-  label: 'Loan status',
+  label: 'Status',
   value: 'status_asc',
 }
 

--- a/src/pages/OffersPage/components/ActiveOffersTable/hooks/useActiveOffersTable.ts
+++ b/src/pages/OffersPage/components/ActiveOffersTable/hooks/useActiveOffersTable.ts
@@ -9,6 +9,7 @@ import { SortOption } from '@banx/components/SortDropdown'
 import { createSolValueJSX } from '@banx/components/TableComponents'
 
 import { PATHS } from '@banx/router'
+import { calculateLoanRepayValue, formatDecimal } from '@banx/utils'
 
 import {
   DEFAULT_SORT_OPTION,
@@ -25,7 +26,7 @@ import styles from '../ActiveOffersTable.module.less'
 interface SearchSelectOption {
   collectionName: string
   collectionImage: string
-  taken: number
+  totalClaim: number
 }
 
 export const useActiveOffersTable = () => {
@@ -44,9 +45,9 @@ export const useActiveOffersTable = () => {
     return map(loansGroupedByCollection, (groupedLoan) => {
       const firstLoanInGroup = first(groupedLoan)
       const { collectionName = '', collectionImage = '' } = firstLoanInGroup?.nft.meta || {}
-      const taken = sumBy(groupedLoan, (nft) => nft.fraktBond.currentPerpetualBorrowed)
+      const totalClaim = sumBy(groupedLoan, (loan) => calculateLoanRepayValue(loan))
 
-      return { collectionName, collectionImage, taken }
+      return { collectionName, collectionImage, totalClaim }
     })
   }, [loans])
 
@@ -57,12 +58,12 @@ export const useActiveOffersTable = () => {
       valueKey: 'collectionName',
       imageKey: 'collectionImage',
       secondLabel: {
-        key: 'taken',
-        format: (value: number) => createSolValueJSX(value, 1e9),
+        key: 'totalClaim',
+        format: (value: number) => createSolValueJSX(value, 1e9, '--', formatDecimal),
       },
     },
     selectedOptions,
-    labels: ['Collection', 'Taken'],
+    labels: ['Collection', 'Total claim'],
     onChange: setSelectedOptions,
     className: styles.searchSelect,
   }

--- a/src/pages/OffersPage/components/ActiveOffersTable/hooks/useActiveOffersTable.ts
+++ b/src/pages/OffersPage/components/ActiveOffersTable/hooks/useActiveOffersTable.ts
@@ -10,7 +10,12 @@ import { createSolValueJSX } from '@banx/components/TableComponents'
 
 import { PATHS } from '@banx/router'
 
-import { DEFAULT_SORT_OPTION, EMPTY_MESSAGE, NOT_CONNECTED_MESSAGE } from '../constants'
+import {
+  DEFAULT_SORT_OPTION,
+  EMPTY_MESSAGE,
+  NOT_CONNECTED_MESSAGE,
+  SORT_OPTIONS,
+} from '../constants'
 import { isLoanAbleToClaim, isLoanAbleToTerminate } from '../helpers'
 import { useLenderLoansAndOffers } from './useLenderLoansAndOffers'
 import { useSortedLenderLoans } from './useSortedOffers'
@@ -65,6 +70,7 @@ export const useActiveOffersTable = () => {
   const sortParams = {
     option: sortOption,
     onChange: setSortOption,
+    options: SORT_OPTIONS,
   }
 
   const filteredLoans = useMemo(() => {

--- a/src/pages/OffersPage/components/HistoryOffersTable/columns.tsx
+++ b/src/pages/OffersPage/components/HistoryOffersTable/columns.tsx
@@ -47,7 +47,7 @@ export const getTableColumns = () => {
     },
     {
       key: 'status',
-      title: <HeaderCell label="Loan status" />,
+      title: <HeaderCell label="Status" />,
       render: (loan) => <StatusCell loan={loan} />,
     },
     {


### PR DESCRIPTION
## Description

Add sorting by LTV on active offers page
Add "Total claim" in active offers search dropdown

## Screenshots

<img width="387" alt="image" src="https://github.com/frakt-solana/banx-ui/assets/60342317/520c1573-c636-4744-8187-8eddeb4c5023">


## Issue link

https://linear.app/banx-gg/issue/BAN-1529/fe-banx-add-sorting-by-ltv-on-active-offers-page

## Vercel preview

https://banx-ui-git-feature-ban-1529-frakt.vercel.app/
