### PR TITLE
BAN-1565: Broken hover on tables

### DIFF
--- a/src/components/Table/views/TableView/TableView.module.less
+++ b/src/components/Table/views/TableView/TableView.module.less
@@ -55,7 +55,7 @@
   tbody {
     tr {
       &:hover {
-        background: var(--bg-action);
+        background: var(--bg-action) !important;
       }
 
       &:nth-child(even) {


### PR DESCRIPTION
## Description

Add important declaration for &:hover table background

## Screenshots

<!-- If applicable -->

## Issue link

https://linear.app/banx-gg/issue/BAN-1565/fe-banx-broken-hover-on-tables

## Vercel preview

https://banx-ui-git-fix-ban-1565-frakt.vercel.app/
