### PR TITLE
BAN-1580: Refinance improvements

### DIFF
--- a/src/pages/RefinancePage/components/RefinanceTable/RefinanceTable.module.less
+++ b/src/pages/RefinancePage/components/RefinanceTable/RefinanceTable.module.less
@@ -7,18 +7,13 @@
 }
 
 .refinanceTable table {
-  tbody > tr > td {
-    min-width: 140px;
-    max-width: 140px;
+  tr > td {
+    min-width: 100px;
+    max-width: 100px;
 
-    &:first-child {
-      min-width: 200px;
-      max-width: 200px;
-    }
-
+    &:first-child,
     &:last-child {
-      min-width: 160px;
-      max-width: 160px;
+      min-width: 176px;
     }
   }
 }

--- a/src/pages/RefinancePage/components/RefinanceTable/RefinanceTable.module.less
+++ b/src/pages/RefinancePage/components/RefinanceTable/RefinanceTable.module.less
@@ -8,12 +8,15 @@
 
 .refinanceTable table {
   tr > td {
-    min-width: 100px;
-    max-width: 100px;
+    min-width: 96px;
+    max-width: 96px;
 
-    &:first-child,
+    &:first-child {
+      min-width: 200px;
+    }
+
     &:last-child {
-      min-width: 176px;
+      min-width: 184px;
     }
   }
 }

--- a/src/pages/RefinancePage/components/RefinanceTable/TableCells/DebtCell.tsx
+++ b/src/pages/RefinancePage/components/RefinanceTable/TableCells/DebtCell.tsx
@@ -1,25 +1,12 @@
 import { FC } from 'react'
 
-import { calculateCurrentInterestSolPure } from 'fbonds-core/lib/fbond-protocol/functions/perpetual'
-import moment from 'moment'
-
 import { createSolValueJSX } from '@banx/components/TableComponents'
 
 import { Loan } from '@banx/api/core'
-import { BONDS } from '@banx/constants'
-import { formatDecimal } from '@banx/utils'
+import { calculateLoanRepayValue, formatDecimal } from '@banx/utils'
 
 export const DebtCell: FC<{ loan: Loan }> = ({ loan }) => {
-  const { solAmount, soldAt, feeAmount, amountOfBonds } = loan.bondTradeTransaction || {}
-
-  const calculatedInterest = calculateCurrentInterestSolPure({
-    loanValue: solAmount + feeAmount,
-    startTime: soldAt,
-    currentTime: moment().unix(),
-    rateBasePoints: amountOfBonds + BONDS.PROTOCOL_REPAY_FEE,
-  })
-
-  const repayValue = solAmount + calculatedInterest + feeAmount
+  const repayValue = calculateLoanRepayValue(loan)
 
   return createSolValueJSX(repayValue, 1e9, '--', formatDecimal)
 }

--- a/src/pages/RefinancePage/components/RefinanceTable/TableCells/LTVCell.tsx
+++ b/src/pages/RefinancePage/components/RefinanceTable/TableCells/LTVCell.tsx
@@ -1,0 +1,21 @@
+import { FC } from 'react'
+
+import { createPercentValueJSX } from '@banx/components/TableComponents'
+
+import { Loan } from '@banx/api/core'
+import { HealthColorIncreasing, calculateLoanRepayValue, getColorByPercent } from '@banx/utils'
+
+interface LTVCellProps {
+  loan: Loan
+}
+
+export const LTVCell: FC<LTVCellProps> = ({ loan }) => {
+  const repayValue = calculateLoanRepayValue(loan)
+
+  const collectionFloor = loan.nft.collectionFloor
+  const ltv = (repayValue / collectionFloor) * 100
+
+  const colorLTV = getColorByPercent(ltv, HealthColorIncreasing)
+
+  return <span style={{ color: colorLTV }}>{createPercentValueJSX(ltv)} LTV</span>
+}

--- a/src/pages/RefinancePage/components/RefinanceTable/TableCells/index.ts
+++ b/src/pages/RefinancePage/components/RefinanceTable/TableCells/index.ts
@@ -1,4 +1,5 @@
 export * from './APRCell'
 export * from './APRIncreaseCell'
 export * from './DebtCell'
+export * from './LTVCell'
 export * from './RefinanceCell'

--- a/src/pages/RefinancePage/components/RefinanceTable/columns.tsx
+++ b/src/pages/RefinancePage/components/RefinanceTable/columns.tsx
@@ -5,7 +5,7 @@ import Timer from '@banx/components/Timer/Timer'
 import { Loan } from '@banx/api/core'
 import { formatDecimal } from '@banx/utils'
 
-import { APRCell, APRIncreaseCell, DebtCell, RefinanceCell } from './TableCells'
+import { APRCell, APRIncreaseCell, DebtCell, LTVCell, RefinanceCell } from './TableCells'
 import { SECONDS_IN_72_HOURS } from './constants'
 import { calcWeeklyInterestFee } from './helpers'
 
@@ -46,6 +46,11 @@ export const getTableColumns = ({
       key: 'repayValue',
       title: <HeaderCell label="Debt" />,
       render: (loan) => <DebtCell loan={loan} />,
+    },
+    {
+      key: 'ltv',
+      title: <HeaderCell label="LTV" />,
+      render: (loan) => <LTVCell loan={loan} />,
     },
     {
       key: 'interest',

--- a/src/pages/RefinancePage/components/RefinanceTable/columns.tsx
+++ b/src/pages/RefinancePage/components/RefinanceTable/columns.tsx
@@ -41,16 +41,19 @@ export const getTableColumns = ({
       key: 'floorPrice',
       title: <HeaderCell label="Floor" />,
       render: (loan) => createSolValueJSX(loan.nft.collectionFloor, 1e9, '--', formatDecimal),
+      sorter: true,
     },
     {
       key: 'repayValue',
       title: <HeaderCell label="Debt" />,
       render: (loan) => <DebtCell loan={loan} />,
+      sorter: true,
     },
     {
       key: 'ltv',
       title: <HeaderCell label="LTV" />,
       render: (loan) => <LTVCell loan={loan} />,
+      sorter: true,
     },
     {
       key: 'interest',
@@ -61,8 +64,8 @@ export const getTableColumns = ({
       key: 'apy',
       title: <HeaderCell label="APY" />,
       render: (loan) => <APRCell loan={loan} />,
+      sorter: true,
     },
-
     {
       key: 'nextAprIncrease',
       title: <HeaderCell label="Next APY increase" />,

--- a/src/pages/RefinancePage/components/RefinanceTable/hooks/useSortedLoans.ts
+++ b/src/pages/RefinancePage/components/RefinanceTable/hooks/useSortedLoans.ts
@@ -1,12 +1,21 @@
 import { useMemo } from 'react'
 
-import { get, sortBy } from 'lodash'
+import { get, isFunction, sortBy } from 'lodash'
 
 import { Loan } from '@banx/api/core'
+import { calculateLoanRepayValue } from '@banx/utils'
+
+import { calculateAprIncrement } from './../helpers'
 
 enum SortField {
   DURATION = 'duration',
+  FLOOR = 'floorPrice',
+  DEBT = 'repayValue',
+  LTV = 'ltv',
+  APY = 'apy',
 }
+
+type SortValueGetter = (loan: Loan) => number
 
 export const useSortedLoans = (loans: Loan[], sortOptionValue: string) => {
   const sortedLoans = useMemo(() => {
@@ -16,13 +25,22 @@ export const useSortedLoans = (loans: Loan[], sortOptionValue: string) => {
 
     const [name, order] = sortOptionValue.split('_')
 
-    const sortValueMapping: Record<SortField, string> = {
+    const sortValueMapping: Record<SortField, string | SortValueGetter> = {
       [SortField.DURATION]: 'fraktBond.refinanceAuctionStartedAt',
+      [SortField.FLOOR]: 'nft.collectionFloor',
+      [SortField.DEBT]: (loan) => calculateLoanRepayValue(loan),
+      [SortField.APY]: (loan) => calculateAprIncrement(loan),
+      [SortField.LTV]: (loan) => {
+        const repayValue = calculateLoanRepayValue(loan)
+        const collectionFloor = loan.nft.collectionFloor
+
+        return repayValue / collectionFloor
+      },
     }
 
     const sorted = sortBy(loans, (loan) => {
       const sortValue = sortValueMapping[name as SortField]
-      return get(loan, sortValue)
+      return isFunction(sortValue) ? sortValue(loan) : get(loan, sortValue)
     })
 
     return order === 'desc' ? sorted.reverse() : sorted


### PR DESCRIPTION
## Description

add LTV as separate column (Debt / Floor price)
add sortings for each column (Floor, Debt, LTV, APY, ends in)

## Screenshots

<img width="1319" alt="image" src="https://github.com/frakt-solana/banx-ui/assets/60342317/37715cbf-871c-4537-979a-1b9538b9408f">

## Issue link

https://linear.app/banx-gg/issue/BAN-1580/fe-banx-refinance-improvements

## Vercel preview

https://banx-ui-git-feature-ban-1580-frakt.vercel.app/
