### PR TITLE
Sync

### DIFF
--- a/src/components/SearchSelect/SearchSelect.tsx
+++ b/src/components/SearchSelect/SearchSelect.tsx
@@ -71,7 +71,7 @@ export const SearchSelect = <P extends object>({
       <PrefixInput />
       <AntdSelect
         mode="multiple"
-        inputValue={inputValue}
+        searchValue={inputValue}
         value={selectedOptions}
         onChange={onChange}
         allowClear

--- a/src/pages/BorrowPage/components/BorrowTable/BorrowTable.module.less
+++ b/src/pages/BorrowPage/components/BorrowTable/BorrowTable.module.less
@@ -24,7 +24,7 @@
 .headerTitleRow {
   display: flex;
   align-items: center;
-  margin-left: 34px;
+  gap: 16px;
 }
 
 .checkbox {

--- a/src/pages/BorrowPage/components/BorrowTable/BorrowTable.tsx
+++ b/src/pages/BorrowPage/components/BorrowTable/BorrowTable.tsx
@@ -16,11 +16,19 @@ interface BorrowTableProps {
 }
 
 const BorrowTable: FC<BorrowTableProps> = ({ nfts, isLoading, rawOffers }) => {
-  const { tableNftData, columns, onRowClick, sortViewParams, nftsInCart, selectAll, borrowAll } =
-    useBorrowTable({
-      nfts,
-      rawOffers,
-    })
+  const {
+    tableNftData,
+    columns,
+    onRowClick,
+    sortViewParams,
+    nftsInCart,
+    selectAmount,
+    borrowAll,
+    maxBorrowAmount,
+  } = useBorrowTable({
+    nfts,
+    rawOffers,
+  })
 
   const rowParams = useMemo(() => {
     return {
@@ -39,7 +47,12 @@ const BorrowTable: FC<BorrowTableProps> = ({ nfts, isLoading, rawOffers }) => {
         loading={isLoading}
         showCard
       />
-      <Summary nftsInCart={nftsInCart} selectAll={selectAll} borrowAll={borrowAll} />
+      <Summary
+        nftsInCart={nftsInCart}
+        borrowAll={borrowAll}
+        selectAmount={selectAmount}
+        maxBorrowAmount={maxBorrowAmount}
+      />
     </div>
   )
 }

--- a/src/pages/BorrowPage/components/BorrowTable/Summary.tsx
+++ b/src/pages/BorrowPage/components/BorrowTable/Summary.tsx
@@ -3,6 +3,7 @@ import { FC, useState } from 'react'
 import { sumBy } from 'lodash'
 
 import { Button } from '@banx/components/Buttons'
+import { CounterSlider } from '@banx/components/Slider'
 import { createSolValueJSX } from '@banx/components/TableComponents'
 
 import { calcLoanValueWithProtocolFee, trackPageEvent } from '@banx/utils'
@@ -15,14 +16,17 @@ import styles from './BorrowTable.module.less'
 
 interface SummaryProps {
   nftsInCart: TableNftData[]
-  selectAll: () => void
   borrowAll: () => Promise<void>
+  selectAmount: (value?: number) => void
+  maxBorrowAmount: number
 }
 
-export const Summary: FC<SummaryProps> = ({ nftsInCart, selectAll, borrowAll }) => {
-  const selectAllBtnText = !nftsInCart.length ? 'Select all' : 'Deselect all'
-  const selectMobileBtnText = !nftsInCart.length ? `Select all` : `Deselect ${nftsInCart.length}`
-
+export const Summary: FC<SummaryProps> = ({
+  maxBorrowAmount,
+  nftsInCart,
+  borrowAll,
+  selectAmount,
+}) => {
   const totalBorrow = calcLoanValueWithProtocolFee(sumBy(nftsInCart, ({ loanValue }) => loanValue))
   const totalWeeklyFee = sumBy(nftsInCart, ({ nft, loanValue }) =>
     calcInterest({
@@ -57,10 +61,7 @@ export const Summary: FC<SummaryProps> = ({ nftsInCart, selectAll, borrowAll }) 
         </div>
       </div>
       <div className={styles.summaryBtns}>
-        <Button variant="secondary" onClick={selectAll}>
-          <span className={styles.selectButtonText}>{selectAllBtnText}</span>
-          <span className={styles.selectButtonMobileText}>{selectMobileBtnText}</span>
-        </Button>
+        <CounterSlider value={nftsInCart.length} onChange={selectAmount} max={maxBorrowAmount} />
         <Button onClick={onBorrow} disabled={!nftsInCart.length} loading={isBorrowing} size="large">
           Borrow {createSolValueJSX(totalBorrow, 1e9, '0◎')}
         </Button>

--- a/src/pages/BorrowPage/components/BorrowTable/columns.tsx
+++ b/src/pages/BorrowPage/components/BorrowTable/columns.tsx
@@ -1,3 +1,4 @@
+import Checkbox from '@banx/components/Checkbox'
 import { ColumnType } from '@banx/components/Table'
 import { HeaderCell, NftInfoCell, createSolValueJSX } from '@banx/components/TableComponents'
 
@@ -14,6 +15,8 @@ interface GetTableColumnsProps {
   onBorrow: (nft: TableNftData) => Promise<void>
   findOfferInCart: (nft: TableNftData) => SimpleOffer | null
   isCardView: boolean
+  hasSelectedNfts: boolean
+  onSelectAll: () => void
 }
 
 export const getTableColumns = ({
@@ -21,12 +24,15 @@ export const getTableColumns = ({
   onNftSelect,
   onBorrow,
   isCardView,
+  hasSelectedNfts,
+  onSelectAll,
 }: GetTableColumnsProps) => {
   const columns: ColumnType<TableNftData>[] = [
     {
       key: 'collateral',
       title: (
         <div className={styles.headerTitleRow}>
+          <Checkbox className={styles.checkbox} onChange={onSelectAll} checked={hasSelectedNfts} />
           <HeaderCell label="Collateral" />
         </div>
       ),


### PR DESCRIPTION
BAN-1212:  Replace "select all" btn with slider on Borrow page (#325)
* Implement CounterSlider component

* Add InputArrowUp icon Add CounterSlider to loans active table

* Add addNftsAmount method in cartState

* Add isNftInCart method for cartState

* Add selectAll checkbox in BorrowTable header

* use searchValue insted of deprecated inputValue in SearchSelect

* Implement slider select functionality for BorrowTable

* Modify addNftsAmount method. Pass mintAndMarketArr instead of mintsByMarket. Select nfts one by one desc

* Fix critical bug with cart. Remove isNftInCart method

* Fix styling for checkbox selectAll

* Remove unused comments

* Refactor cartState. Remove addNftsAuto method.
Use addNfts(prev. addNftsAmount) for selectAll on BorrowPage either

* Namings refactor

