### PR TITLE
BAN-1583: Add select all checkbox to refinance page

### DIFF
--- a/src/pages/RefinancePage/components/RefinanceTable/RefinanceTable.module.less
+++ b/src/pages/RefinancePage/components/RefinanceTable/RefinanceTable.module.less
@@ -146,3 +146,14 @@
     }
   }
 }
+
+.headerTitleRow {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.checkbox {
+  height: 18px;
+  padding-left: 18px;
+}

--- a/src/pages/RefinancePage/components/RefinanceTable/RefinanceTable.tsx
+++ b/src/pages/RefinancePage/components/RefinanceTable/RefinanceTable.tsx
@@ -24,10 +24,21 @@ export const RefinanceTable = () => {
 
   const { viewState } = useTableView()
 
+  const hasSelectedLoans = !!selectedLoans.length
+  const onSelectAll = () => {
+    if (hasSelectedLoans) {
+      onDeselectAllLoans()
+    } else {
+      onSelectLoans(loans)
+    }
+  }
+
   const columns = getTableColumns({
     isCardView: viewState === ViewState.CARD,
     onSelectLoan,
     findSelectedLoan,
+    onSelectAll,
+    hasSelectedLoans,
   })
 
   const goToLendPage = () => {

--- a/src/pages/RefinancePage/components/RefinanceTable/columns.tsx
+++ b/src/pages/RefinancePage/components/RefinanceTable/columns.tsx
@@ -1,3 +1,4 @@
+import Checkbox from '@banx/components/Checkbox'
 import { ColumnType } from '@banx/components/Table'
 import { HeaderCell, NftInfoCell, createSolValueJSX } from '@banx/components/TableComponents'
 import Timer from '@banx/components/Timer/Timer'
@@ -9,21 +10,32 @@ import { APRCell, APRIncreaseCell, DebtCell, LTVCell, RefinanceCell } from './Ta
 import { SECONDS_IN_72_HOURS } from './constants'
 import { calcWeeklyInterestFee } from './helpers'
 
+import styles from './RefinanceTable.module.less'
+
 interface GetTableColumnsProps {
   onSelectLoan: (loan: Loan) => void
   findSelectedLoan: (loanPubkey: string) => Loan | undefined
+  onSelectAll: () => void
   isCardView: boolean
+  hasSelectedLoans: boolean
 }
 
 export const getTableColumns = ({
   isCardView,
   onSelectLoan,
   findSelectedLoan,
+  onSelectAll,
+  hasSelectedLoans,
 }: GetTableColumnsProps) => {
   const columns: ColumnType<Loan>[] = [
     {
       key: 'collateral',
-      title: <HeaderCell label="Collateral" align="left" />,
+      title: (
+        <div className={styles.headerTitleRow}>
+          <Checkbox className={styles.checkbox} onChange={onSelectAll} checked={hasSelectedLoans} />
+          <HeaderCell label="Collateral" />
+        </div>
+      ),
       render: (loan) => (
         <NftInfoCell
           selected={!!findSelectedLoan(loan.publicKey)}


### PR DESCRIPTION
## Description

 Add select all checkbox to refinance page

## Screenshots

<img width="1281" alt="image" src="https://github.com/frakt-solana/banx-ui/assets/60342317/9a29d882-5cb7-4b13-bf00-b7bcab5ac164">

## Issue link

https://linear.app/banx-gg/issue/BAN-1583/fe-banx-add-select-all-checkbox-to-refi-page

## Vercel preview

https://banx-ui-git-feature-ban-1583-frakt.vercel.app/
