### PR TITLE
BAN-1561: Add filter by hot markets on Lend page

### DIFF
--- a/src/pages/LendPage/components/FilterSection/FilterSection.module.less
+++ b/src/pages/LendPage/components/FilterSection/FilterSection.module.less
@@ -25,10 +25,18 @@
 
 .filterButton {
   svg path {
-    fill: #fa8c16;
+    fill: var(--additional-orange-primary);
   }
 
   &.active {
     border-color: var(--content-primary);
+  }
+
+  &.disabled {
+    background: var(--bg-secondary);
+
+    svg path {
+      fill: var(--bg-border-active);
+    }
   }
 }

--- a/src/pages/LendPage/components/FilterSection/FilterSection.module.less
+++ b/src/pages/LendPage/components/FilterSection/FilterSection.module.less
@@ -12,6 +12,13 @@
   }
 }
 
+.filterWrapper {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+}
+
 .searchSelect {
   max-width: 750px;
 }

--- a/src/pages/LendPage/components/FilterSection/FilterSection.module.less
+++ b/src/pages/LendPage/components/FilterSection/FilterSection.module.less
@@ -15,10 +15,20 @@
 .filterWrapper {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 24px;
   width: 100%;
 }
 
 .searchSelect {
   max-width: 750px;
+}
+
+.filterButton {
+  svg path {
+    fill: #fa8c16;
+  }
+
+  &.active {
+    border-color: var(--content-primary);
+  }
 }

--- a/src/pages/LendPage/components/FilterSection/FilterSection.tsx
+++ b/src/pages/LendPage/components/FilterSection/FilterSection.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react'
 
+import classNames from 'classnames'
+
 import { Button } from '@banx/components/Buttons'
 import { SearchSelect, SearchSelectProps } from '@banx/components/SearchSelect'
 import { SortDropdown, SortDropdownProps } from '@banx/components/SortDropdown'
@@ -11,11 +13,15 @@ import styles from './FilterSection.module.less'
 interface FilterSectionProps<T> {
   searchSelectParams: SearchSelectProps<T>
   sortParams: SortDropdownProps
+  onToggleHotFilter: () => void
+  isHotFilterActive: boolean
 }
 
 const FilterSection = <T extends object>({
   searchSelectParams,
   sortParams,
+  onToggleHotFilter,
+  isHotFilterActive,
 }: FilterSectionProps<T>) => {
   const [searchSelectCollapsed, setSearchSelectCollapsed] = useState(true)
 
@@ -28,7 +34,12 @@ const FilterSection = <T extends object>({
           collapsed={searchSelectCollapsed}
           onChangeCollapsed={setSearchSelectCollapsed}
         />
-        <Button type="circle" variant="secondary">
+        <Button
+          className={classNames(styles.filterButton, { [styles.active]: isHotFilterActive })}
+          onClick={onToggleHotFilter}
+          variant="secondary"
+          type="circle"
+        >
           <Fire />
         </Button>
       </div>

--- a/src/pages/LendPage/components/FilterSection/FilterSection.tsx
+++ b/src/pages/LendPage/components/FilterSection/FilterSection.tsx
@@ -41,7 +41,11 @@ const FilterSection = <T extends object>({
         <Tooltip title="Hot collections">
           <>
             <Button
-              className={classNames(styles.filterButton, { [styles.active]: isHotFilterActive })}
+              className={classNames(
+                styles.filterButton,
+                { [styles.active]: isHotFilterActive },
+                { [styles.disabled]: !hotMarkets?.length },
+              )}
               onClick={onToggleHotFilter}
               disabled={!hotMarkets?.length}
               variant="secondary"

--- a/src/pages/LendPage/components/FilterSection/FilterSection.tsx
+++ b/src/pages/LendPage/components/FilterSection/FilterSection.tsx
@@ -5,7 +5,9 @@ import classNames from 'classnames'
 import { Button } from '@banx/components/Buttons'
 import { SearchSelect, SearchSelectProps } from '@banx/components/SearchSelect'
 import { SortDropdown, SortDropdownProps } from '@banx/components/SortDropdown'
+import Tooltip from '@banx/components/Tooltip'
 
+import { MarketPreview } from '@banx/api/core'
 import { Fire } from '@banx/icons'
 
 import styles from './FilterSection.module.less'
@@ -15,6 +17,7 @@ interface FilterSectionProps<T> {
   sortParams: SortDropdownProps
   onToggleHotFilter: () => void
   isHotFilterActive: boolean
+  hotMarkets: MarketPreview[]
 }
 
 const FilterSection = <T extends object>({
@@ -22,6 +25,7 @@ const FilterSection = <T extends object>({
   sortParams,
   onToggleHotFilter,
   isHotFilterActive,
+  hotMarkets,
 }: FilterSectionProps<T>) => {
   const [searchSelectCollapsed, setSearchSelectCollapsed] = useState(true)
 
@@ -34,14 +38,19 @@ const FilterSection = <T extends object>({
           collapsed={searchSelectCollapsed}
           onChangeCollapsed={setSearchSelectCollapsed}
         />
-        <Button
-          className={classNames(styles.filterButton, { [styles.active]: isHotFilterActive })}
-          onClick={onToggleHotFilter}
-          variant="secondary"
-          type="circle"
-        >
-          <Fire />
-        </Button>
+        <Tooltip title="Hot collections">
+          <>
+            <Button
+              className={classNames(styles.filterButton, { [styles.active]: isHotFilterActive })}
+              onClick={onToggleHotFilter}
+              disabled={!hotMarkets?.length}
+              variant="secondary"
+              type="circle"
+            >
+              <Fire />
+            </Button>
+          </>
+        </Tooltip>
       </div>
       {searchSelectCollapsed && <SortDropdown {...sortParams} />}
     </div>

--- a/src/pages/LendPage/components/FilterSection/FilterSection.tsx
+++ b/src/pages/LendPage/components/FilterSection/FilterSection.tsx
@@ -1,7 +1,10 @@
 import { useState } from 'react'
 
+import { Button } from '@banx/components/Buttons'
 import { SearchSelect, SearchSelectProps } from '@banx/components/SearchSelect'
 import { SortDropdown, SortDropdownProps } from '@banx/components/SortDropdown'
+
+import { Fire } from '@banx/icons'
 
 import styles from './FilterSection.module.less'
 
@@ -18,12 +21,17 @@ const FilterSection = <T extends object>({
 
   return (
     <div className={styles.container}>
-      <SearchSelect
-        {...searchSelectParams}
-        className={styles.searchSelect}
-        collapsed={searchSelectCollapsed}
-        onChangeCollapsed={setSearchSelectCollapsed}
-      />
+      <div className={styles.filterWrapper}>
+        <SearchSelect
+          {...searchSelectParams}
+          className={styles.searchSelect}
+          collapsed={searchSelectCollapsed}
+          onChangeCollapsed={setSearchSelectCollapsed}
+        />
+        <Button type="circle" variant="secondary">
+          <Fire />
+        </Button>
+      </div>
       {searchSelectCollapsed && <SortDropdown {...sortParams} />}
     </div>
   )

--- a/src/pages/LendPage/components/LendPageContent/LendPageContent.tsx
+++ b/src/pages/LendPage/components/LendPageContent/LendPageContent.tsx
@@ -22,6 +22,7 @@ const LendPageContent = () => {
     showEmptyList,
     onToggleHotFilter,
     isHotFilterActive,
+    hotMarkets,
   } = useLendPageContent()
 
   const { data: markets, fetchMoreTrigger } = useFakeInfinityScroll({ rawData: marketsPreview })
@@ -33,6 +34,7 @@ const LendPageContent = () => {
         sortParams={sortParams}
         isHotFilterActive={isHotFilterActive}
         onToggleHotFilter={onToggleHotFilter}
+        hotMarkets={hotMarkets}
       />
       {isLoading && isEmpty(marketsPreview) ? (
         <Loader />

--- a/src/pages/LendPage/components/LendPageContent/LendPageContent.tsx
+++ b/src/pages/LendPage/components/LendPageContent/LendPageContent.tsx
@@ -14,14 +14,26 @@ import styles from './LendPageContent.module.less'
 
 const LendPageContent = () => {
   const { visibleMarkets, toggleMarketVisibility } = useMarketsURLControl(true)
-  const { marketsPreview, isLoading, searchSelectParams, sortParams, showEmptyList } =
-    useLendPageContent()
+  const {
+    marketsPreview,
+    isLoading,
+    searchSelectParams,
+    sortParams,
+    showEmptyList,
+    onToggleHotFilter,
+    isHotFilterActive,
+  } = useLendPageContent()
 
   const { data: markets, fetchMoreTrigger } = useFakeInfinityScroll({ rawData: marketsPreview })
 
   return (
     <div className={classNames(styles.content, { [styles.selected]: !!visibleMarkets?.length })}>
-      <FilterSection searchSelectParams={searchSelectParams} sortParams={sortParams} />
+      <FilterSection
+        searchSelectParams={searchSelectParams}
+        sortParams={sortParams}
+        isHotFilterActive={isHotFilterActive}
+        onToggleHotFilter={onToggleHotFilter}
+      />
       {isLoading && isEmpty(marketsPreview) ? (
         <Loader />
       ) : (

--- a/src/pages/LendPage/components/LendPageContent/hooks/useLendPageContent.tsx
+++ b/src/pages/LendPage/components/LendPageContent/hooks/useLendPageContent.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react'
 
-import { filter, sortBy } from 'lodash'
+import { filter } from 'lodash'
 
 import { SearchSelectProps } from '@banx/components/SearchSelect'
 import Tooltip from '@banx/components/Tooltip'
@@ -19,8 +19,6 @@ export const useLendPageContent = () => {
   const { selectedMarkets, setSelectedMarkets } = useMarketsURLControl()
   const [isHotFilterActive, setIsHotFilterActive] = useState(false)
 
-  const showEmptyList = !isLoading && !marketsPreview?.length
-
   const handleFilterChange = (filteredOptions: string[]) => {
     setSelectedMarkets(filteredOptions)
   }
@@ -34,14 +32,12 @@ export const useLendPageContent = () => {
   )
 
   const filteredHotMarkets = useMemo(() => {
-    if (isHotFilterActive) {
-      const hotMarkets = filter(sortedMarkets, 'isHot')
-      const sortedHotMarkets = sortBy(hotMarkets, 'loansTvl').reverse()
+    if (isHotFilterActive) return filter(sortedMarkets, 'isHot')
 
-      return sortedHotMarkets
-    }
     return sortedMarkets
   }, [isHotFilterActive, sortedMarkets])
+
+  const showEmptyList = !isLoading && !filteredHotMarkets?.length
 
   const searchSelectParams: SearchSelectProps<MarketPreview> = {
     options: marketsPreview,

--- a/src/pages/LendPage/components/LendPageContent/hooks/useLendPageContent.tsx
+++ b/src/pages/LendPage/components/LendPageContent/hooks/useLendPageContent.tsx
@@ -37,7 +37,7 @@ export const useLendPageContent = () => {
   const showEmptyList = !isLoading && !filteredHotMarkets?.length
 
   const searchSelectParams: SearchSelectProps<MarketPreview> = {
-    options: marketsPreview,
+    options: isHotFilterActive ? hotMarkets : marketsPreview,
     selectedOptions: selectedMarkets,
     placeholder: 'Select a collection',
     labels: ['Collection', 'APY'],

--- a/src/pages/LendPage/components/LendPageContent/hooks/useLendPageContent.tsx
+++ b/src/pages/LendPage/components/LendPageContent/hooks/useLendPageContent.tsx
@@ -31,11 +31,8 @@ export const useLendPageContent = () => {
     filteredMarkets.length ? filteredMarkets : marketsPreview,
   )
 
-  const filteredHotMarkets = useMemo(() => {
-    if (isHotFilterActive) return filter(sortedMarkets, 'isHot')
-
-    return sortedMarkets
-  }, [isHotFilterActive, sortedMarkets])
+  const hotMarkets = filter(sortedMarkets, 'isHot')
+  const filteredHotMarkets = isHotFilterActive ? hotMarkets : sortedMarkets
 
   const showEmptyList = !isLoading && !filteredHotMarkets?.length
 
@@ -71,6 +68,7 @@ export const useLendPageContent = () => {
     searchSelectParams,
     sortParams,
     isHotFilterActive,
+    hotMarkets,
     onToggleHotFilter: () => setIsHotFilterActive(!isHotFilterActive),
   }
 }

--- a/src/pages/LendPage/components/LendPageContent/hooks/useLendPageContent.tsx
+++ b/src/pages/LendPage/components/LendPageContent/hooks/useLendPageContent.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react'
 
-import { partition, sortBy } from 'lodash'
+import { filter, sortBy } from 'lodash'
 
 import { SearchSelectProps } from '@banx/components/SearchSelect'
 import Tooltip from '@banx/components/Tooltip'
@@ -33,13 +33,12 @@ export const useLendPageContent = () => {
     filteredMarkets.length ? filteredMarkets : marketsPreview,
   )
 
-  const sortedAndFilteredMarkets = useMemo(() => {
+  const filteredHotMarkets = useMemo(() => {
     if (isHotFilterActive) {
-      const [hotMarkets, nonHotMarkets] = partition(sortedMarkets, 'isHot')
+      const hotMarkets = filter(sortedMarkets, 'isHot')
       const sortedHotMarkets = sortBy(hotMarkets, 'loansTvl').reverse()
-      const sortedNonHotMarkets = sortBy(nonHotMarkets, 'loansTvl').reverse()
 
-      return [...sortedHotMarkets, ...sortedNonHotMarkets]
+      return sortedHotMarkets
     }
     return sortedMarkets
   }, [isHotFilterActive, sortedMarkets])
@@ -70,7 +69,7 @@ export const useLendPageContent = () => {
   }
 
   return {
-    marketsPreview: sortedAndFilteredMarkets,
+    marketsPreview: filteredHotMarkets,
     isLoading,
     showEmptyList,
     searchSelectParams,


### PR DESCRIPTION
## Description

Add filter by hot markets on Lend page

## Screenshots

<img width="1276" alt="image" src="https://github.com/frakt-solana/banx-ui/assets/60342317/d3cd43fa-a906-454a-b3bc-c7417f60ccc8">


## Issue link

https://linear.app/banx-gg/issue/BAN-1561/fe-banx-add-filter-by-hot-markets-on-lend-page

## Vercel preview

https://banx-ui-git-feature-ban-1561-frakt.vercel.app/
