### PR TITLE
BAN-1616:  Auto price reset on offer creating

### DIFF
--- a/src/components/WalletModal/components.tsx
+++ b/src/components/WalletModal/components.tsx
@@ -38,7 +38,7 @@ const UserGeneralInfo = () => {
 
 const UserBalance = () => {
   const { publicKey } = useWallet()
-  const solanaBalance = useSolanaBalance({})
+  const solanaBalance = useSolanaBalance()
 
   const publicKeyString = publicKey?.toBase58() || ''
 

--- a/src/components/WalletModal/components.tsx
+++ b/src/components/WalletModal/components.tsx
@@ -38,7 +38,7 @@ const UserGeneralInfo = () => {
 
 const UserBalance = () => {
   const { publicKey } = useWallet()
-  const solanaBalance = useSolanaBalance()
+  const solanaBalance = useSolanaBalance({ isLive: true })
 
   const publicKeyString = publicKey?.toBase58() || ''
 

--- a/src/components/WalletModal/components.tsx
+++ b/src/components/WalletModal/components.tsx
@@ -38,7 +38,7 @@ const UserGeneralInfo = () => {
 
 const UserBalance = () => {
   const { publicKey } = useWallet()
-  const solanaBalance = useSolanaBalance({ isLive: true })
+  const solanaBalance = useSolanaBalance({})
 
   const publicKeyString = publicKey?.toBase58() || ''
 

--- a/src/pages/LendPage/components/PlaceOfferTab/hooks/usePlaceOfferTab.ts
+++ b/src/pages/LendPage/components/PlaceOfferTab/hooks/usePlaceOfferTab.ts
@@ -21,7 +21,7 @@ export const usePlaceOfferTab = (props: OrderBookMarketParams) => {
 
   const { offers, updateOrAddOffer } = useMarketOffers({ marketPubkey })
   const { marketsPreview } = useMarketsPreview()
-  const solanaBalance = useSolanaBalance(false)
+  const solanaBalance = useSolanaBalance({ isLive: false })
 
   const {
     findOfferByPubkey: findSyntheticOfferByPubkey,

--- a/src/pages/LendPage/components/PlaceOfferTab/hooks/usePlaceOfferTab.ts
+++ b/src/pages/LendPage/components/PlaceOfferTab/hooks/usePlaceOfferTab.ts
@@ -21,7 +21,7 @@ export const usePlaceOfferTab = (props: OrderBookMarketParams) => {
 
   const { offers, updateOrAddOffer } = useMarketOffers({ marketPubkey })
   const { marketsPreview } = useMarketsPreview()
-  const solanaBalance = useSolanaBalance()
+  const solanaBalance = useSolanaBalance(false)
 
   const {
     findOfferByPubkey: findSyntheticOfferByPubkey,

--- a/src/utils/accounts/index.ts
+++ b/src/utils/accounts/index.ts
@@ -33,8 +33,8 @@ const useNativeAccount: UseNativeAccount = ({ isLive = true }) => {
   return nativeAccount
 }
 
-type UseSolanaBalance = ({ isLive }: { isLive?: boolean }) => number
-export const useSolanaBalance: UseSolanaBalance = ({ isLive = true }) => {
+type UseSolanaBalance = (options?: { isLive?: boolean }) => number
+export const useSolanaBalance: UseSolanaBalance = ({ isLive = true } = {}) => {
   const account = useNativeAccount({ isLive })
 
   const balance = (account?.lamports || 0) / web3.LAMPORTS_PER_SOL

--- a/src/utils/accounts/index.ts
+++ b/src/utils/accounts/index.ts
@@ -3,8 +3,8 @@ import { useEffect, useState } from 'react'
 import { useConnection, useWallet } from '@solana/wallet-adapter-react'
 import { web3 } from 'fbonds-core'
 
-type UseNativeAccount = (isLive: boolean) => web3.AccountInfo<Buffer> | null
-const useNativeAccount: UseNativeAccount = (isLive) => {
+type UseNativeAccount = ({ isLive }: { isLive: boolean }) => web3.AccountInfo<Buffer> | null
+const useNativeAccount: UseNativeAccount = ({ isLive }) => {
   const { connection } = useConnection()
   const { wallet, publicKey } = useWallet()
 
@@ -33,8 +33,9 @@ const useNativeAccount: UseNativeAccount = (isLive) => {
   return nativeAccount
 }
 
-export const useSolanaBalance = (isLive = true) => {
-  const account = useNativeAccount(isLive)
+type UseSolanaBalance = ({ isLive }: { isLive: boolean }) => number
+export const useSolanaBalance: UseSolanaBalance = ({ isLive }) => {
+  const account = useNativeAccount({ isLive })
 
   const balance = (account?.lamports || 0) / web3.LAMPORTS_PER_SOL
 

--- a/src/utils/accounts/index.ts
+++ b/src/utils/accounts/index.ts
@@ -3,9 +3,8 @@ import { useEffect, useState } from 'react'
 import { useConnection, useWallet } from '@solana/wallet-adapter-react'
 import { web3 } from 'fbonds-core'
 
-const useNativeAccount = (): {
-  account: web3.AccountInfo<Buffer> | null
-} => {
+type UseNativeAccount = (isLive: boolean) => web3.AccountInfo<Buffer> | null
+const useNativeAccount: UseNativeAccount = (isLive) => {
   const { connection } = useConnection()
   const { wallet, publicKey } = useWallet()
 
@@ -21,18 +20,21 @@ const useNativeAccount = (): {
         setNativeAccount(acc)
       }
     })
-    connection.onAccountChange(publicKey, (acc) => {
-      if (acc) {
-        setNativeAccount(acc)
-      }
-    })
-  }, [wallet, publicKey, connection])
 
-  return { account: nativeAccount }
+    if (isLive) {
+      connection.onAccountChange(publicKey, (acc) => {
+        if (acc) {
+          setNativeAccount(acc)
+        }
+      })
+    }
+  }, [wallet, publicKey, connection, isLive])
+
+  return nativeAccount
 }
 
-export const useSolanaBalance = () => {
-  const { account } = useNativeAccount()
+export const useSolanaBalance = (isLive = true) => {
+  const account = useNativeAccount(isLive)
 
   const balance = (account?.lamports || 0) / web3.LAMPORTS_PER_SOL
 

--- a/src/utils/accounts/index.ts
+++ b/src/utils/accounts/index.ts
@@ -3,8 +3,8 @@ import { useEffect, useState } from 'react'
 import { useConnection, useWallet } from '@solana/wallet-adapter-react'
 import { web3 } from 'fbonds-core'
 
-type UseNativeAccount = ({ isLive }: { isLive: boolean }) => web3.AccountInfo<Buffer> | null
-const useNativeAccount: UseNativeAccount = ({ isLive }) => {
+type UseNativeAccount = ({ isLive }: { isLive?: boolean }) => web3.AccountInfo<Buffer> | null
+const useNativeAccount: UseNativeAccount = ({ isLive = true }) => {
   const { connection } = useConnection()
   const { wallet, publicKey } = useWallet()
 
@@ -33,8 +33,8 @@ const useNativeAccount: UseNativeAccount = ({ isLive }) => {
   return nativeAccount
 }
 
-type UseSolanaBalance = ({ isLive }: { isLive: boolean }) => number
-export const useSolanaBalance: UseSolanaBalance = ({ isLive }) => {
+type UseSolanaBalance = ({ isLive }: { isLive?: boolean }) => number
+export const useSolanaBalance: UseSolanaBalance = ({ isLive = true }) => {
   const account = useNativeAccount({ isLive })
 
   const balance = (account?.lamports || 0) / web3.LAMPORTS_PER_SOL


### PR DESCRIPTION
## Description

Add isLive prop to subscribe on onAccountChange to prevent rerenders bug

## Screenshots

<!-- If applicable -->

## Issue link

https://linear.app/banx-gg/issue/BAN-1616/fe-banx-auto-price-reset-on-offer-creating

## Vercel preview

https://banx-ui-git-feature-ban-1616-frakt.vercel.app/
