### PR TITLE
BAN-1616:  Auto price reset on offer creating (#358)

### DIFF
--- a/src/pages/LendPage/components/PlaceOfferTab/hooks/usePlaceOfferTab.ts
+++ b/src/pages/LendPage/components/PlaceOfferTab/hooks/usePlaceOfferTab.ts
@@ -21,7 +21,7 @@ export const usePlaceOfferTab = (props: OrderBookMarketParams) => {
 
   const { offers, updateOrAddOffer } = useMarketOffers({ marketPubkey })
   const { marketsPreview } = useMarketsPreview()
-  const solanaBalance = useSolanaBalance()
+  const solanaBalance = useSolanaBalance({ isLive: false })
 
   const {
     findOfferByPubkey: findSyntheticOfferByPubkey,

--- a/src/utils/accounts/index.ts
+++ b/src/utils/accounts/index.ts
@@ -3,9 +3,8 @@ import { useEffect, useState } from 'react'
 import { useConnection, useWallet } from '@solana/wallet-adapter-react'
 import { web3 } from 'fbonds-core'
 
-const useNativeAccount = (): {
-  account: web3.AccountInfo<Buffer> | null
-} => {
+type UseNativeAccount = ({ isLive }: { isLive?: boolean }) => web3.AccountInfo<Buffer> | null
+const useNativeAccount: UseNativeAccount = ({ isLive = true }) => {
   const { connection } = useConnection()
   const { wallet, publicKey } = useWallet()
 
@@ -21,18 +20,22 @@ const useNativeAccount = (): {
         setNativeAccount(acc)
       }
     })
-    connection.onAccountChange(publicKey, (acc) => {
-      if (acc) {
-        setNativeAccount(acc)
-      }
-    })
-  }, [wallet, publicKey, connection])
 
-  return { account: nativeAccount }
+    if (isLive) {
+      connection.onAccountChange(publicKey, (acc) => {
+        if (acc) {
+          setNativeAccount(acc)
+        }
+      })
+    }
+  }, [wallet, publicKey, connection, isLive])
+
+  return nativeAccount
 }
 
-export const useSolanaBalance = () => {
-  const { account } = useNativeAccount()
+type UseSolanaBalance = (options?: { isLive?: boolean }) => number
+export const useSolanaBalance: UseSolanaBalance = ({ isLive = true } = {}) => {
+  const account = useNativeAccount({ isLive })
 
   const balance = (account?.lamports || 0) / web3.LAMPORTS_PER_SOL
 


### PR DESCRIPTION
* Add isLive prop to subscribe on onAccountChange to prevent rerenders bug

* Make prop as object in useSolanaBalance, useNativeAccount for better readability

* Make isLive as optional param with "true" as default value

* Refactor useSolanaBalance for better readability
