### PR TITLE
BAN-1418: No keyboard on mobile search

### DIFF
--- a/src/components/SearchSelect/SearchSelect.tsx
+++ b/src/components/SearchSelect/SearchSelect.tsx
@@ -58,7 +58,10 @@ export const SearchSelect = <P extends object>({
     return (
       <CollapsedContent
         selectedOptions={selectedOptions}
-        onClick={() => onChangeCollapsed?.(!collapsed)}
+        onClick={() => {
+          onChangeCollapsed?.(!collapsed)
+          handleDropdownVisibleChange(!collapsed)
+        }}
       />
     )
 

--- a/src/components/SearchSelect/SearchSelect.tsx
+++ b/src/components/SearchSelect/SearchSelect.tsx
@@ -47,7 +47,6 @@ export const SearchSelect = <P extends object>({
   const {
     containerRef,
     isPopupOpen,
-    defaultOpen,
     handleDropdownVisibleChange,
     handleInputChange,
     showSufixIcon,
@@ -85,7 +84,6 @@ export const SearchSelect = <P extends object>({
         suffixIcon={showSufixIcon && <SuffixIcon isPopupOpen={isPopupOpen} />}
         onSearch={handleInputChange}
         onDropdownVisibleChange={handleDropdownVisibleChange}
-        defaultOpen={defaultOpen}
         maxTagCount="responsive"
         dropdownRender={(menu) => (
           <>

--- a/src/components/SearchSelect/hooks.ts
+++ b/src/components/SearchSelect/hooks.ts
@@ -46,12 +46,9 @@ export const useSearchSelect = ({
   const showSufixIcon = !selectedOptions?.length && !inputValue
   const showCollapsedContent = collapsed && isMobile && onChangeCollapsed
 
-  const defaultOpen = !collapsed && isMobile
-
   return {
     containerRef,
     isPopupOpen,
-    defaultOpen,
 
     inputValue,
     handleInputChange,

--- a/src/pages/DashboardPage/components/DashboardBorrowTab/DashboardBorrowTab.module.less
+++ b/src/pages/DashboardPage/components/DashboardBorrowTab/DashboardBorrowTab.module.less
@@ -22,7 +22,7 @@
   margin-top: 12px;
   padding-bottom: 12px;
   overflow: auto;
-  z-index: 1; //? prevent bug with SerchSelect overlap on phantom mobile app
+  z-index: 1; //? prevent bug with SearchSelect overlap on phantom mobile app
 
   @media (max-width: 1240px) {
     display: flex;

--- a/src/pages/DashboardPage/components/DashboardBorrowTab/DashboardBorrowTab.module.less
+++ b/src/pages/DashboardPage/components/DashboardBorrowTab/DashboardBorrowTab.module.less
@@ -22,6 +22,7 @@
   margin-top: 12px;
   padding-bottom: 12px;
   overflow: auto;
+  z-index: 1; //? prevent bug with SerchSelect overlap on phantom mobile app
 
   @media (max-width: 1240px) {
     display: flex;

--- a/src/pages/DashboardPage/components/DashboardLendTab/DashboardLendTab.module.less
+++ b/src/pages/DashboardPage/components/DashboardLendTab/DashboardLendTab.module.less
@@ -22,7 +22,7 @@
   padding-bottom: 12px;
   gap: 24px;
   overflow: auto;
-  z-index: 1; //? prevent bug with SerchSelect overlap on phantom mobile app
+  z-index: 1; //? prevent bug with SearchSelect overlap on phantom mobile app
 
   @media (max-width: 1240px) {
     display: flex;

--- a/src/pages/DashboardPage/components/DashboardLendTab/DashboardLendTab.module.less
+++ b/src/pages/DashboardPage/components/DashboardLendTab/DashboardLendTab.module.less
@@ -22,6 +22,7 @@
   padding-bottom: 12px;
   gap: 24px;
   overflow: auto;
+  z-index: 1; //? prevent bug with SerchSelect overlap on phantom mobile app
 
   @media (max-width: 1240px) {
     display: flex;


### PR DESCRIPTION
## Description

[Remove defaultOpen prop to prevent bug with keyboard on mobile](https://github.com/frakt-solana/banx-ui/pull/430/commits/8b13104a507c6b64db3098ac4624cbd03689b941)
[prevent bug with SerchSelect overlap on phantom mobile app](https://github.com/frakt-solana/banx-ui/pull/430/commits/9708e88a534f89824d7a074f56b2a4af8319e558)

## Screenshots

<!-- If applicable -->

## Issue link

https://linear.app/banx-gg/issue/BAN-1418/fe-no-keyboard-on-mobile-search

## Vercel preview

https://banx-ui-git-bugfix-ban-1418-frakt.vercel.app/
