### PR TITLE
BAN-1764: Add "No hot collections currently" on disabled hot collection btn

### DIFF
--- a/src/pages/LendPage/components/FilterSection/FilterSection.tsx
+++ b/src/pages/LendPage/components/FilterSection/FilterSection.tsx
@@ -28,6 +28,7 @@ const FilterSection = <T extends object>({
   hotMarkets,
 }: FilterSectionProps<T>) => {
   const [searchSelectCollapsed, setSearchSelectCollapsed] = useState(true)
+  const disabledHotFilterAction = !hotMarkets?.length
 
   return (
     <div className={styles.container}>
@@ -38,16 +39,18 @@ const FilterSection = <T extends object>({
           collapsed={searchSelectCollapsed}
           onChangeCollapsed={setSearchSelectCollapsed}
         />
-        <Tooltip title="Hot collections">
+        <Tooltip
+          title={disabledHotFilterAction ? 'No hot collections currently' : 'Hot collections'}
+        >
           <>
             <Button
               className={classNames(
                 styles.filterButton,
                 { [styles.active]: isHotFilterActive },
-                { [styles.disabled]: !hotMarkets?.length },
+                { [styles.disabled]: disabledHotFilterAction },
               )}
               onClick={onToggleHotFilter}
-              disabled={!hotMarkets?.length}
+              disabled={disabledHotFilterAction}
               variant="secondary"
               type="circle"
             >


### PR DESCRIPTION
## Description

Add "No hot collections currently" on disabled hot collection btn

## Screenshots

<img width="1038" alt="image" src="https://github.com/frakt-solana/banx-ui/assets/60342317/8e30cd5a-5132-4690-9331-ca77363d1825">


## Issue link

https://linear.app/banx-gg/issue/BAN-1764/fe-banx-add-no-hot-collections-currently-on-disabled-hot-collection

## Vercel preview

https://banx-ui-git-feature-ban-1764-frakt.vercel.app/
