### PR TITLE
BAN-1826: Fix not correct loanValue in calculateLoanValue helper

### DIFF
--- a/src/pages/BorrowPage/hooks.ts
+++ b/src/pages/BorrowPage/hooks.ts
@@ -107,7 +107,7 @@ export const useBorrowNfts = () => {
         const mergedOffers = sortBy(
           [...nextOffers, ...optimisticsWithSameMarket],
           calculateLoanValue,
-        )
+        ).reverse()
 
         return [marketPubkey, mergedOffers]
       })

--- a/src/pages/DashboardPage/components/DashboardBorrowTab/components/CardsList.tsx
+++ b/src/pages/DashboardPage/components/DashboardBorrowTab/components/CardsList.tsx
@@ -4,7 +4,11 @@ import { useWallet } from '@solana/wallet-adapter-react'
 
 import { BorrowNft, MarketPreview, Offer } from '@banx/api/core'
 import { useFakeInfinityScroll } from '@banx/hooks'
-import { calculateLoanValue } from '@banx/utils'
+import {
+  calcBorrowValueWithProtocolFee,
+  calcBorrowValueWithRentFee,
+  calculateLoanValue,
+} from '@banx/utils'
 
 import { BorrowCard } from '../../Card'
 import { calcDailyInterestFee } from '../helpers'
@@ -67,7 +71,14 @@ const NFTCard: FC<NFTCardProps> = ({ borrowNft, borrow, findBestOffer }) => {
     const bestOffer = findBestOffer(loan.marketPubkey)
     if (!bestOffer) return 0
 
-    return calculateLoanValue(bestOffer)
+    const loanValueWithProtocolFee = calcBorrowValueWithProtocolFee(calculateLoanValue(bestOffer))
+
+    const borrowValueWithRentFee = calcBorrowValueWithRentFee(
+      loanValueWithProtocolFee,
+      loan.marketPubkey,
+    )
+
+    return borrowValueWithRentFee
   }, [findBestOffer, loan.marketPubkey])
 
   return (

--- a/src/pages/DashboardPage/components/DashboardBorrowTab/components/CardsList.tsx
+++ b/src/pages/DashboardPage/components/DashboardBorrowTab/components/CardsList.tsx
@@ -63,11 +63,12 @@ const NFTCard: FC<NFTCardProps> = ({ borrowNft, borrow, findBestOffer }) => {
     collectionFloor: nft.collectionFloor,
   })
 
-  const bestOffer = useMemo(
-    () => findBestOffer(loan.marketPubkey),
-    [findBestOffer, loan.marketPubkey],
-  )
-  const bestLoanValue = bestOffer ? calculateLoanValue(bestOffer) : 0
+  const bestLoanValue = useMemo(() => {
+    const bestOffer = findBestOffer(loan.marketPubkey)
+    if (!bestOffer) return 0
+
+    return calculateLoanValue(bestOffer)
+  }, [findBestOffer, loan.marketPubkey])
 
   return (
     <BorrowCard

--- a/src/utils/offers/index.ts
+++ b/src/utils/offers/index.ts
@@ -1,4 +1,5 @@
-import { PairState } from 'fbonds-core/lib/fbond-protocol/types'
+import { getMaxLoanValueFromBondOffer } from 'fbonds-core/lib/fbond-protocol/helpers'
+import { BondOfferV2, PairState } from 'fbonds-core/lib/fbond-protocol/types'
 
 import { Offer } from '@banx/api/core'
 
@@ -11,12 +12,13 @@ export const сalculateLoansAmount = (offer: Offer) => {
 }
 
 export const calculateLoanValue = (offer: Offer) => {
-  const { currentSpotPrice } = offer
+  return getMaxLoanValueFromBondOffer(offer as BondOfferV2)
+  // const { currentSpotPrice } = offer
 
-  const loansAmount = сalculateLoansAmount(offer)
-  const loanValue = currentSpotPrice * Math.min(loansAmount, 1)
+  // const loansAmount = сalculateLoansAmount(offer)
+  // const loanValue = currentSpotPrice * Math.min(loansAmount, 1)
 
-  return loanValue
+  // return loanValue
 }
 
 export const isOfferClosed = (pairState: string) => {


### PR DESCRIPTION
Add sort by loan value in mergedRawOffers (useBorrowNfts) Add new "getMaxLoanValueFromBondOffer" helper

## Description

<!-- Describe your changes here -->

## Screenshots

<!-- If applicable -->

## Issue link

https://linear.app/banx-gg/issue/BAN-1826/fe-fix-borrowvalue-on-dashboard

## Vercel preview

https://banx-ui-git-bugfix-ban-1826-frakt.vercel.app/
