### PR TITLE
Sync

### DIFF
--- a/src/pages/BorrowPage/hooks.ts
+++ b/src/pages/BorrowPage/hooks.ts
@@ -3,10 +3,10 @@ import { useEffect, useMemo } from 'react'
 import { useWallet } from '@solana/wallet-adapter-react'
 import { useQuery } from '@tanstack/react-query'
 import { produce } from 'immer'
-import { chain, filter, groupBy, isEmpty, map, maxBy, sumBy, uniqBy } from 'lodash'
+import { chain, filter, groupBy, isEmpty, map, maxBy, sortBy, sumBy, uniqBy } from 'lodash'
 import { create } from 'zustand'
 
-import { BorrowNft, fetchBorrowNftsAndOffers } from '@banx/api/core'
+import { BorrowNft, Offer, fetchBorrowNftsAndOffers } from '@banx/api/core'
 import {
   isOfferNewer,
   isOptimisticLoanExpired,
@@ -18,6 +18,7 @@ import { convertLoanToBorrowNft } from '@banx/transactions'
 import {
   calcBorrowValueWithProtocolFee,
   calcBorrowValueWithRentFee,
+  calculateLoanValue,
   isLoanActiveOrRefinanced,
   isLoanRepaid,
   isOfferClosed,
@@ -89,8 +90,9 @@ export const useBorrowNfts = () => {
 
     const optimisticsByMarket = groupBy(optimisticsFiltered, ({ offer }) => offer.hadoMarket)
 
-    return Object.fromEntries(
-      Object.entries(data.offers).map(([marketPubkey, offers]) => {
+    return chain(data.offers)
+      .entries()
+      .map(([marketPubkey, offers]) => {
         const nextOffers = offers.filter((offer) => {
           const sameOptimistic = optimisticsByMarket[offer.hadoMarket]?.find(
             ({ offer: optimisticOffer }) => optimisticOffer.publicKey === offer.publicKey,
@@ -102,9 +104,15 @@ export const useBorrowNfts = () => {
         const optimisticsWithSameMarket =
           optimisticsByMarket[marketPubkey]?.map(({ offer }) => offer) || []
 
-        return [marketPubkey, [...nextOffers, ...optimisticsWithSameMarket]]
-      }),
-    )
+        const mergedOffers = sortBy(
+          [...nextOffers, ...optimisticsWithSameMarket],
+          calculateLoanValue,
+        ).reverse()
+
+        return [marketPubkey, mergedOffers]
+      })
+      .fromPairs()
+      .value() as Record<string, Offer[]>
   }, [data, optimisticOffers, walletPublicKey])
 
   const simpleOffers = useMemo(() => {

--- a/src/pages/DashboardPage/components/DashboardBorrowTab/components/CardsList.tsx
+++ b/src/pages/DashboardPage/components/DashboardBorrowTab/components/CardsList.tsx
@@ -4,7 +4,11 @@ import { useWallet } from '@solana/wallet-adapter-react'
 
 import { BorrowNft, MarketPreview, Offer } from '@banx/api/core'
 import { useFakeInfinityScroll } from '@banx/hooks'
-import { calculateLoanValue } from '@banx/utils'
+import {
+  calcBorrowValueWithProtocolFee,
+  calcBorrowValueWithRentFee,
+  calculateLoanValue,
+} from '@banx/utils'
 
 import { BorrowCard } from '../../Card'
 import { calcDailyInterestFee } from '../helpers'
@@ -63,11 +67,19 @@ const NFTCard: FC<NFTCardProps> = ({ borrowNft, borrow, findBestOffer }) => {
     collectionFloor: nft.collectionFloor,
   })
 
-  const bestOffer = useMemo(
-    () => findBestOffer(loan.marketPubkey),
-    [findBestOffer, loan.marketPubkey],
-  )
-  const bestLoanValue = bestOffer ? calculateLoanValue(bestOffer) : 0
+  const bestLoanValue = useMemo(() => {
+    const bestOffer = findBestOffer(loan.marketPubkey)
+    if (!bestOffer) return 0
+
+    const loanValueWithProtocolFee = calcBorrowValueWithProtocolFee(calculateLoanValue(bestOffer))
+
+    const borrowValueWithRentFee = calcBorrowValueWithRentFee(
+      loanValueWithProtocolFee,
+      loan.marketPubkey,
+    )
+
+    return borrowValueWithRentFee
+  }, [findBestOffer, loan.marketPubkey])
 
   return (
     <BorrowCard

--- a/src/utils/offers/index.ts
+++ b/src/utils/offers/index.ts
@@ -1,4 +1,5 @@
-import { PairState } from 'fbonds-core/lib/fbond-protocol/types'
+import { getMaxLoanValueFromBondOffer } from 'fbonds-core/lib/fbond-protocol/helpers'
+import { BondOfferV2, PairState } from 'fbonds-core/lib/fbond-protocol/types'
 
 import { Offer } from '@banx/api/core'
 
@@ -11,12 +12,13 @@ export const сalculateLoansAmount = (offer: Offer) => {
 }
 
 export const calculateLoanValue = (offer: Offer) => {
-  const { currentSpotPrice } = offer
+  return getMaxLoanValueFromBondOffer(offer as BondOfferV2)
+  // const { currentSpotPrice } = offer
 
-  const loansAmount = сalculateLoansAmount(offer)
-  const loanValue = currentSpotPrice * Math.min(loansAmount, 1)
+  // const loansAmount = сalculateLoansAmount(offer)
+  // const loanValue = currentSpotPrice * Math.min(loansAmount, 1)
 
-  return loanValue
+  // return loanValue
 }
 
 export const isOfferClosed = (pairState: string) => {


### PR DESCRIPTION
BAN-1826: Fix not correct loanValue in calculateLoanValue helper (#471)
* Fix not correct loanValue in calculateLoanValue helper Add sort by loan value in mergedRawOffers (useBorrowNfts) Add new "getMaxLoanValueFromBondOffer" helper

* Change mergedOffers sorting

* Add calcBorrowValueWithRentFee and calcBorrowValueWithProtocolFee
