### PR TITLE
BAN-1886: Dynamic APR build improvements

### DIFF
--- a/src/pages/BorrowPage/components/BorrowTable/Summary/Summary.tsx
+++ b/src/pages/BorrowPage/components/BorrowTable/Summary/Summary.tsx
@@ -1,6 +1,8 @@
 import { FC, useState } from 'react'
 
 import classNames from 'classnames'
+import { BASE_POINTS } from 'fbonds-core/lib/fbond-protocol/constants'
+import { calculateDynamicApr } from 'fbonds-core/lib/fbond-protocol/functions/perpetual'
 import { sumBy } from 'lodash'
 
 import { Button } from '@banx/components/Buttons'
@@ -8,6 +10,7 @@ import { CounterSlider, Slider } from '@banx/components/Slider'
 import { createSolValueJSX } from '@banx/components/TableComponents'
 import Tooltip from '@banx/components/Tooltip'
 
+import { DYNAMIC_APR } from '@banx/constants'
 import {
   calcBorrowValueWithProtocolFee,
   calcBorrowValueWithRentFee,
@@ -48,13 +51,14 @@ export const Summary: FC<SummaryProps> = ({
     return loanValue - calcBorrowValueWithProtocolFee(loanValue)
   })
 
-  const totalWeeklyFee = sumBy(nftsInCart, ({ nft, loanValue }) =>
-    calcInterest({
-      timeInterval: ONE_WEEK_IN_SECONDS,
-      loanValue,
-      apr: nft.loan.marketApr,
-    }),
-  )
+  const totalWeeklyFee = sumBy(nftsInCart, ({ nft, loanValue }) => {
+    const apr = calculateDynamicApr(
+      Math.floor((loanValue / nft.nft.collectionFloor) * BASE_POINTS),
+      DYNAMIC_APR,
+    )
+
+    return calcInterest({ timeInterval: ONE_WEEK_IN_SECONDS, loanValue, apr })
+  })
 
   const [isBorrowing, setIsBorrowing] = useState(false)
   const onBorrow = async () => {

--- a/src/pages/LendPage/components/MarketOverviewInfo/MarketOverviewInfo.tsx
+++ b/src/pages/LendPage/components/MarketOverviewInfo/MarketOverviewInfo.tsx
@@ -3,7 +3,7 @@ import { FC } from 'react'
 import { Tooltip } from 'antd'
 import classNames from 'classnames'
 
-import { MIN_APR_VALUE } from '@banx/components/PlaceOfferSection'
+import { MAX_APR_VALUE } from '@banx/components/PlaceOfferSection'
 import { StatInfo, VALUES_TYPES } from '@banx/components/StatInfo'
 
 import { MarketPreview } from '@banx/api/core'
@@ -69,7 +69,7 @@ export const MarketAdditionalInfo: FC<MarketAdditionalInfoProps> = ({ market, is
       />
       <StatInfo
         label="Max apr"
-        value={MIN_APR_VALUE}
+        value={MAX_APR_VALUE}
         classNamesProps={{ value: styles.aprValue }}
         tooltipText="Maximum annual interest rate. Ranges between 34-104% APR depending on the loan-to-value (LTV) offered, and becomes fixed once offer is taken"
         valueType={VALUES_TYPES.PERCENT}

--- a/src/pages/LoansPage/components/LoansActiveTable/columns.tsx
+++ b/src/pages/LoansPage/components/LoansActiveTable/columns.tsx
@@ -55,15 +55,15 @@ export const getTableColumns = ({
       sorter: true,
     },
     {
-      key: 'apr',
-      title: <HeaderCell label="APR" />,
-      render: (loan) => <APRCell loan={loan} />,
-      sorter: true,
-    },
-    {
       key: 'ltv',
       title: <HeaderCell label="LTV" />,
       render: (loan) => <LTVCell loan={loan} />,
+      sorter: true,
+    },
+    {
+      key: 'apr',
+      title: <HeaderCell label="APR" />,
+      render: (loan) => <APRCell loan={loan} />,
       sorter: true,
     },
     {

--- a/src/pages/OffersPage/components/ActiveTabContent/components/LoansTable/hooks.ts
+++ b/src/pages/OffersPage/components/ActiveTabContent/components/LoansTable/hooks.ts
@@ -25,12 +25,12 @@ const SORT_OPTIONS = [
   { label: 'Status', value: 'status' },
 ]
 
-const DEFAULT_SORT_OPTION = { label: 'Status', value: 'status_desc' }
+const DEFAULT_SORT_OPTION = { label: 'LTV', value: 'ltv_desc' }
 
 const STATUS_VALUE_MAP: StatusValueMap = {
   [SortField.LENT]: (loan: Loan) => loan.fraktBond.currentPerpetualBorrowed,
   [SortField.APR]: (loan: Loan) => loan.bondTradeTransaction.amountOfBonds,
-  [SortField.LTV]: (loan: Loan) => loan.nft.collectionFloor / calculateLoanRepayValue(loan),
+  [SortField.LTV]: (loan: Loan) => calculateLoanRepayValue(loan) / loan.nft.collectionFloor,
   [SortField.STATUS]: '',
 }
 

--- a/src/pages/OffersPage/components/OffersTabContent/hooks/useSortedOffers.ts
+++ b/src/pages/OffersPage/components/OffersTabContent/hooks/useSortedOffers.ts
@@ -20,8 +20,8 @@ const SORT_OPTIONS = [
 ]
 
 const DEFAULT_SORT_OPTION: SortOption = {
-  label: SORT_OPTIONS[0].label,
-  value: `${SORT_OPTIONS[0].value}_desc`,
+  label: SORT_OPTIONS[2].label,
+  value: `${SORT_OPTIONS[2].value}_desc`,
 }
 
 type SortValueGetter = (offer: UserOffer) => number
@@ -31,7 +31,7 @@ const STATUS_VALUE_MAP: StatusValueMap = {
   [SortField.LENT]: ({ offer }) => offer.edgeSettlement,
   [SortField.INTEREST]: ({ offer }) => offer.concentrationIndex,
   [SortField.LTV]: ({ offer, collectionMeta }) =>
-    calcSyntheticLoanValue(offer) / collectionMeta.collectionFloor,
+    collectionMeta.collectionFloor / calcSyntheticLoanValue(offer),
 }
 
 export const useSortedOffers = (offers: UserOffer[]) => {


### PR DESCRIPTION
## Description

1. Fix wrong calculating of weekly fee on summary on borrow
2. Hardcode max APR on 104%
3. Set default sorting on "My offers" -> Active and Pending on " LTV" desc 
4. Change APR order on My loans page

## Screenshots

<!-- If applicable -->

## Issue link

https://linear.app/banx-gg/issue/BAN-1886/fe-banx-dynamic-apr-build-improvements

## Vercel preview

https://banx-ui-git-feature-ban-1886-frakt.vercel.app/
