### PR TITLE
BAN-1939: Add rewards availability indicator

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export * from './useBestWorkingRPC'
+export * from './useBorrowBonkRewardsAvailability'
 export * from './useContainerWidth'
 export * from './useCountdown'
 export * from './useDebounce'

--- a/src/hooks/useBorrowBonkRewardsAvailability.tsx
+++ b/src/hooks/useBorrowBonkRewardsAvailability.tsx
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { fetchBorrowBonkRewardsAvailability } from '@banx/api/activity'
+
+export const useBorrowBonkRewardsAvailability = () => {
+  const { data: bonkRewardsAvailable } = useQuery(
+    ['borrowBonkRewardsAvailability'],
+    () => fetchBorrowBonkRewardsAvailability(),
+    {
+      staleTime: 20 * 1000, //? 20 sec
+      refetchInterval: 30 * 1000, //? 30 sec
+      refetchOnWindowFocus: false,
+    },
+  )
+  return bonkRewardsAvailable || false
+}

--- a/src/pages/BorrowPage/components/BorrowTable/hooks.ts
+++ b/src/pages/BorrowPage/components/BorrowTable/hooks.ts
@@ -1,7 +1,6 @@
 import { useCallback, useMemo, useState } from 'react'
 
 import { useConnection, useWallet } from '@solana/wallet-adapter-react'
-import { useQuery } from '@tanstack/react-query'
 import { chain, filter, first, get, groupBy, includes, isEmpty, map, sortBy, sumBy } from 'lodash'
 import { useNavigate } from 'react-router-dom'
 
@@ -13,9 +12,9 @@ import {
   createLoanSubscribeNotificationsTitle,
 } from '@banx/components/modals'
 
-import { fetchBorrowBonkRewardsAvailability } from '@banx/api/activity'
 import { BorrowNft, Offer } from '@banx/api/core'
 import { SPECIAL_COLLECTIONS_MARKETS } from '@banx/constants'
+import { useBorrowBonkRewardsAvailability } from '@banx/hooks'
 import { PATHS } from '@banx/router'
 import {
   ViewState,
@@ -335,17 +334,4 @@ const useSortedNfts = (nfts: TableNftData[], sortOptionValue: string) => {
   }, [sortOptionValue, nfts])
 
   return sortedLoans
-}
-
-export const useBorrowBonkRewardsAvailability = () => {
-  const { data: bonkRewardsAvailable } = useQuery(
-    ['borrowBonkRewardsAvailability'],
-    () => fetchBorrowBonkRewardsAvailability(),
-    {
-      staleTime: 20 * 1000, //? 20 sec
-      refetchInterval: 30 * 1000, //? 30 sec
-      refetchOnWindowFocus: false,
-    },
-  )
-  return bonkRewardsAvailable || false
 }

--- a/src/pages/LeaderboardPage/components/RewardsTab/RewardsTab.module.less
+++ b/src/pages/LeaderboardPage/components/RewardsTab/RewardsTab.module.less
@@ -67,6 +67,17 @@
     }
   }
 }
+.bonkRewards {
+  background: var(--additional-green-secondary);
+  color: var(--additional-green-primary-deep);
+  padding: 0 8px;
+  border-radius: 100px;
+
+  &Off {
+    background: var(--bg-secondary);
+    color: var(--content-secondary);
+  }
+}
 .weeklyRewardsBorrowBtn {
   text-decoration: none;
   button {

--- a/src/pages/LeaderboardPage/components/RewardsTab/RewardsTab.tsx
+++ b/src/pages/LeaderboardPage/components/RewardsTab/RewardsTab.tsx
@@ -1,6 +1,7 @@
 import { FC, useState } from 'react'
 
 import { useWallet } from '@solana/wallet-adapter-react'
+import classNames from 'classnames'
 import { web3 } from 'fbonds-core'
 import { NavLink } from 'react-router-dom'
 
@@ -9,6 +10,7 @@ import EmptyList from '@banx/components/EmptyList'
 import { Loader } from '@banx/components/Loader'
 
 import { fetchBonkWithdrawal, sendBonkWithdrawal } from '@banx/api/user'
+import { useBorrowBonkRewardsAvailability } from '@banx/hooks'
 import { CircleCheck } from '@banx/icons'
 import { PATHS } from '@banx/router'
 import { enqueueUnknownErrorSnackbar } from '@banx/transactions'
@@ -43,6 +45,8 @@ interface ClaimRewardsBlockProps {
   totalWeekRewards: number
 }
 const ClaimRewardsBlock: FC<ClaimRewardsBlockProps> = ({ totalWeekRewards }) => {
+  const bonkRewardsAvailable = useBorrowBonkRewardsAvailability()
+
   return (
     <div className={styles.weeklyRewardsBlock}>
       <div className={styles.weeklyRewardsInfoRow}>
@@ -65,6 +69,14 @@ const ClaimRewardsBlock: FC<ClaimRewardsBlockProps> = ({ totalWeekRewards }) => 
         </li>
         <li>
           <CircleCheck /> The more you borrow, the more you earn
+        </li>
+        <li>
+          100 loans/day availability:{' '}
+          {bonkRewardsAvailable ? (
+            <span className={styles.bonkRewards}>On</span>
+          ) : (
+            <span className={classNames(styles.bonkRewards, styles.bonkRewardsOff)}>Off</span>
+          )}
         </li>
       </ul>
 


### PR DESCRIPTION
## Screenshots
![image](https://github.com/frakt-solana/banx-ui/assets/24393100/d79ed1d6-a71c-4beb-96ff-225ad53e1c70)

## Issue link

https://linear.app/banx-gg/issue/BAN-1939/fe-banx-add-rewords-availability-indicator

## Vercel preview

https://banx-ui-git-feature-ban-1939-frakt.vercel.app/
