### PR TITLE
BAN-1926: Fix slider color on BorrowPage

### DIFF
--- a/src/less/antd/slider.less
+++ b/src/less/antd/slider.less
@@ -2,19 +2,23 @@
   margin: 0 !important;
 
   .ant-slider-rail,
-  .ant-slider:hover .ant-slider-rail {
+  &:hover .ant-slider-rail {
     background: var(--accent-primary-sub) !important;
     height: 4px;
   }
 
-  .ant-slider-track,
-  .ant-slider:hover .ant-slider-track {
-    background: var(--accent-primary) !important;
+  .ant-slider-track {
+    background: var(--accent-primary);
+    border: 2px solid var(--accent-primary);
+  }
+
+  &:hover .ant-slider-track {
+    background: var(--accent-primary);
     border: 2px solid var(--accent-primary);
   }
 
   .ant-slider-dot,
-  .ant-slider:hover .ant-slider-dot {
+  &:hover .ant-slider-dot {
     background: var(--bg-primary);
     border: 2px solid var(--accent-primary-sub) !important;
     height: 8px;
@@ -22,7 +26,7 @@
   }
 
   .ant-slider-dot-active,
-  .ant-slider:hover .ant-slider-dot-active {
+  &:hover .ant-slider-dot-active {
     background: var(--bg-primary);
     border: 2px solid var(--accent-primary) !important;
   }


### PR DESCRIPTION

## Screenshots
![image](https://github.com/frakt-solana/banx-ui/assets/24393100/38cdd51e-d75a-4e13-9a45-8c16fd2fce48)


## Issue link

https://linear.app/banx-gg/issue/BAN-1926/fe-fix-slider-color-on-borrowpage

## Vercel preview

https://banx-ui-git-bugfix-ban-1926-frakt.vercel.app/
