### PR TITLE
BAN-1924: Update apr on dasboard / lend page

### DIFF
--- a/src/pages/DashboardPage/components/Card/Card.tsx
+++ b/src/pages/DashboardPage/components/Card/Card.tsx
@@ -5,11 +5,11 @@ import classNames from 'classnames'
 
 import { Button } from '@banx/components/Buttons'
 import ImageWithPreload from '@banx/components/ImageWithPreload'
+import { MAX_APR_VALUE } from '@banx/components/PlaceOfferSection'
 import { StatInfo, VALUES_TYPES } from '@banx/components/StatInfo'
-import { createPercentValueJSX, createSolValueJSX } from '@banx/components/TableComponents'
+import { createSolValueJSX } from '@banx/components/TableComponents'
 
 import { Snowflake } from '@banx/icons'
-import { convertAprToApy } from '@banx/utils'
 
 import styles from './Card.module.less'
 
@@ -53,8 +53,7 @@ interface LendCardProps extends CardProps {
 export const LendCard: FC<LendCardProps> = ({ amountOfLoans, offerTvl, apr, ...props }) => {
   const BadgeContentElement = apr ? (
     <div className={styles.lendCardBadge}>
-      {createPercentValueJSX(convertAprToApy(apr / 1e4))}
-      <span>APR</span>
+      {MAX_APR_VALUE}%<span>MAX APR</span>
     </div>
   ) : null
 

--- a/src/pages/DashboardPage/components/DashboardLendTab/hooks.ts
+++ b/src/pages/DashboardPage/components/DashboardLendTab/hooks.ts
@@ -2,11 +2,11 @@ import { useMemo, useState } from 'react'
 
 import { filter, includes } from 'lodash'
 
+import { MAX_APR_VALUE } from '@banx/components/PlaceOfferSection'
 import { createPercentValueJSX } from '@banx/components/TableComponents'
 
 import { MarketPreview } from '@banx/api/core'
 import { useMarketsPreview } from '@banx/pages/LendPage/hooks'
-import { convertAprToApy } from '@banx/utils'
 
 export const useDashboardLendTab = () => {
   const { marketsPreview } = useMarketsPreview()
@@ -41,10 +41,10 @@ const useFilteredMarkets = (marketsPreview: MarketPreview[]) => {
       imageKey: 'collectionImage',
       secondLabel: {
         key: 'marketApr',
-        format: (apr: number) => createPercentValueJSX(convertAprToApy(apr / 1e4)),
+        format: () => createPercentValueJSX(MAX_APR_VALUE),
       },
     },
-    labels: ['Collection', 'APR'],
+    labels: ['Collection', 'Max APR'],
   }
 
   return { filteredMarkets, searchSelectParams }

--- a/src/pages/LendPage/components/LendPageContent/hooks/useLendPageContent.tsx
+++ b/src/pages/LendPage/components/LendPageContent/hooks/useLendPageContent.tsx
@@ -2,14 +2,15 @@ import { useMemo, useState } from 'react'
 
 import { filter } from 'lodash'
 
+import { MAX_APR_VALUE } from '@banx/components/PlaceOfferSection'
 import { SearchSelectProps } from '@banx/components/SearchSelect'
+import { createPercentValueJSX } from '@banx/components/TableComponents'
 import Tooltip from '@banx/components/Tooltip'
 
 import { MarketPreview } from '@banx/api/core'
 import { Fire } from '@banx/icons'
 import { useMarketsPreview } from '@banx/pages/LendPage/hooks'
 import { useMarketsURLControl } from '@banx/store'
-import { convertAprToApy } from '@banx/utils'
 
 import { useSortMarkets } from './useSortMarkets'
 
@@ -55,7 +56,7 @@ export const useLendPageContent = () => {
       },
       secondLabel: {
         key: 'marketApr',
-        format: (value: number) => `${convertAprToApy(value / 1e4)} %`,
+        format: () => createPercentValueJSX(MAX_APR_VALUE),
       },
     },
     onChange: handleFilterChange,

--- a/src/pages/LendPage/components/LendPageContent/hooks/useLendPageContent.tsx
+++ b/src/pages/LendPage/components/LendPageContent/hooks/useLendPageContent.tsx
@@ -40,7 +40,7 @@ export const useLendPageContent = () => {
     options: isHotFilterActive ? hotMarkets : marketsPreview,
     selectedOptions: selectedMarkets,
     placeholder: 'Select a collection',
-    labels: ['Collection', 'APR'],
+    labels: ['Collection', 'Max APR'],
     optionKeys: {
       labelKey: 'collectionName',
       valueKey: 'marketPubkey',


### PR DESCRIPTION
## Description

 Update apr on dasboard / lend page

## Screenshots

![image](https://github.com/frakt-solana/banx-ui/assets/60342317/709f5ce8-ed23-4ab3-b437-c4cd4634f873)

## Issue link

https://linear.app/banx-gg/issue/BAN-1924/fe-banx-update-apr-on-dasboard-page-in-cards

## Vercel preview

https://banx-ui-git-feature-ban-1924-new-frakt.vercel.app/
