### PR TITLE
BAN-1952: Fix bug with menu-links if top message is displayed

### DIFF
--- a/src/Layout/components/Navbar/Navbar.module.less
+++ b/src/Layout/components/Navbar/Navbar.module.less
@@ -5,7 +5,7 @@
   display: flex;
   flex-direction: column;
   overflow-y: scroll;
-  height: 100vh;
+  height: 100%;
   width: 192px;
 
   @media (max-width: 960px) {
@@ -65,12 +65,13 @@
   display: flex;
   justify-content: space-evenly;
   align-items: flex-end;
+  padding-bottom: 8px;
+  height: 100vh;
   width: 100%;
-  height: 100%;
-  padding-bottom: 82px;
 
   @media (max-width: 960px) {
     padding-bottom: 0;
+    height: 100%;
   }
 
   & > a {


### PR DESCRIPTION
## Description

Fix bug with menu-links if top message is displayed

## Screenshots

![image](https://github.com/frakt-solana/banx-ui/assets/60342317/7140bb63-8d08-46e0-ba52-302f8cb11b57)


## Issue link

https://linear.app/banx-gg/issue/BAN-1952/fe-banx-cant-see-menu-links-if-top-message-is-displayed

## Vercel preview

https://banx-ui-git-bugfix-ban-1952-frakt.vercel.app/
