### PR TITLE
BAN-1966: Remove protocol repay fee from calculateClaimValue

### DIFF
--- a/src/pages/OffersPage/helpers.ts
+++ b/src/pages/OffersPage/helpers.ts
@@ -3,7 +3,6 @@ import { chain, first } from 'lodash'
 import moment from 'moment'
 
 import { Loan, Offer } from '@banx/api/core'
-import { BONDS } from '@banx/constants'
 import {
   calcLoanBorrowedAmount,
   calculateLoanRepayValue,
@@ -61,7 +60,7 @@ export const calculateClaimValue = (loan: Loan) => {
     loanValue: loanBorrowedAmount,
     startTime: soldAt,
     currentTime: moment().unix(),
-    rateBasePoints: amountOfBonds + BONDS.PROTOCOL_REPAY_FEE,
+    rateBasePoints: amountOfBonds,
   }
 
   const currentInterest = calculateCurrentInterestSolPure(interestParameters)


### PR DESCRIPTION
## Description

Remove protocol repay fee from calculateClaimValue

## Screenshots

<!-- If applicable -->

## Issue link

https://linear.app/banx-gg/issue/BAN-1966/fe-banx-recalculate-exit-amount-in-manage-modal

## Vercel preview

<!-- Insert link here -->
