### PR TITLE
BAN-2034: selectAll checkbox keeps checked after manage actions execution

### DIFF
--- a/src/pages/OffersPage/components/ActiveTabContent/components/LoansTable/TableCells/ActionsCell/ActionsCell.tsx
+++ b/src/pages/OffersPage/components/ActiveTabContent/components/LoansTable/TableCells/ActionsCell/ActionsCell.tsx
@@ -73,7 +73,10 @@ export const ActionsCell: FC<ActionsCellProps> = ({ loan, isCardView = false }) 
       {!canClaim && (
         <Button
           className={styles.actionButton}
-          onClick={showModal}
+          onClick={(event) => {
+            showModal()
+            event.stopPropagation()
+          }}
           disabled={isTerminatingStatus}
           variant="secondary"
           size={buttonSize}

--- a/src/pages/OffersPage/components/ActiveTabContent/components/LoansTable/TableCells/ActionsCell/ManageModal.tsx
+++ b/src/pages/OffersPage/components/ActiveTabContent/components/LoansTable/TableCells/ActionsCell/ManageModal.tsx
@@ -25,6 +25,8 @@ import {
   isLoanTerminating,
 } from '@banx/utils'
 
+import { useSelectedLoans } from '../../loansState'
+
 import styles from './ActionsCell.module.less'
 
 interface ManageModalProps {
@@ -76,6 +78,8 @@ const ClosureContent: FC<ClosureContentProps> = ({ loan }) => {
   const { connection } = useConnection()
   const { close } = useModal()
 
+  const { remove: removeLoan } = useSelectedLoans()
+
   const { updateOrAddLoan, addMints: hideLoans } = useLenderLoans()
 
   const { offers, updateOrAddOffer, isLoading } = useMarketOffers({
@@ -119,6 +123,8 @@ const ClosureContent: FC<ClosureContentProps> = ({ loan }) => {
           type: 'success',
           solanaExplorerPath: `tx/${txnHash}`,
         })
+
+        removeLoan(loan.publicKey, wallet?.publicKey?.toBase58() || '')
       })
       .on('pfSuccessAll', () => {
         close()


### PR DESCRIPTION
## Description

Add stopPropagation on manage button onClick

## Screenshots

<!-- If applicable -->

## Issue link

https://linear.app/banx-gg/issue/BAN-2034/fe-banx-selectall-checkbox-keeps-checked-after-manage-actions

## Vercel preview

https://banx-ui-git-bugfix-ban-2034-frakt.vercel.app/
