### PR TITLE
BAN-2139: Fix sorting by APR on Refi

### DIFF
--- a/src/pages/RefinancePage/components/RefinanceTable/helpers.ts
+++ b/src/pages/RefinancePage/components/RefinanceTable/helpers.ts
@@ -1,35 +1,14 @@
-import moment from 'moment'
-
 import { Loan } from '@banx/api/core'
 import { BONDS, WEEKS_IN_YEAR } from '@banx/constants'
 import { calculateLoanRepayValue } from '@banx/utils'
 
-export const calculateAprIncrement = (loan: Loan) => {
-  const { amountOfBonds } = loan.bondTradeTransaction
-  const { refinanceAuctionStartedAt } = loan.fraktBond
-
-  const currentTime = moment()
-  const auctionStartTime = moment.unix(refinanceAuctionStartedAt)
-  const hoursSinceStart = currentTime.diff(auctionStartTime, 'hours')
-
-  const aprIncrement = amountOfBonds / 100 + hoursSinceStart
-
-  return aprIncrement
-}
-
 type CalcWeeklyInterestFee = (Loan: Loan) => number
 export const calcWeeklyInterestFee: CalcWeeklyInterestFee = (loan) => {
-  //? calculate weekly interest with default apr
   const aprInPercent = loan.bondTradeTransaction.amountOfBonds / 100
   const aprWithProtocolFee = aprInPercent + BONDS.PROTOCOL_REPAY_FEE / 100
   const repayValue = calculateLoanRepayValue(loan)
 
   const weeklyAprPercentage = aprWithProtocolFee / 100 / WEEKS_IN_YEAR
-
-  //? calculate weekly interest with incremented apr
-  // const aprIncrement = calculateAprIncrement(loan)
-  // const aprIncrementWithProtocolFee = aprIncrement + BONDS.PROTOCOL_REPAY_FEE / 100
-  // const weeklyAprPercentage = aprIncrementWithProtocolFee / 100 / WEEKS_IN_YEAR
 
   const weeklyFee = weeklyAprPercentage * repayValue
 

--- a/src/pages/RefinancePage/components/RefinanceTable/hooks/useSortedLoans.ts
+++ b/src/pages/RefinancePage/components/RefinanceTable/hooks/useSortedLoans.ts
@@ -5,8 +5,6 @@ import { get, isFunction, sortBy } from 'lodash'
 import { Loan } from '@banx/api/core'
 import { calculateLoanRepayValue } from '@banx/utils'
 
-import { calculateAprIncrement } from './../helpers'
-
 enum SortField {
   DURATION = 'duration',
   FLOOR = 'floorPrice',
@@ -26,10 +24,10 @@ export const useSortedLoans = (loans: Loan[], sortOptionValue: string) => {
     const [name, order] = sortOptionValue.split('_')
 
     const sortValueMapping: Record<SortField, string | SortValueGetter> = {
-      [SortField.DURATION]: 'fraktBond.refinanceAuctionStartedAt',
-      [SortField.FLOOR]: 'nft.collectionFloor',
+      [SortField.DURATION]: (loan) => loan.fraktBond.refinanceAuctionStartedAt,
+      [SortField.FLOOR]: (loan) => loan.nft.collectionFloor,
       [SortField.DEBT]: (loan) => calculateLoanRepayValue(loan),
-      [SortField.APR]: (loan) => calculateAprIncrement(loan),
+      [SortField.APR]: (loan) => loan.bondTradeTransaction.amountOfBonds,
       [SortField.LTV]: (loan) => {
         const repayValue = calculateLoanRepayValue(loan)
         const collectionFloor = loan.nft.collectionFloor


### PR DESCRIPTION
## Description

Fix apr sorting on RefinancePage
Remove unnecessary calculateAprIncrement helper

## Screenshots

<!-- If applicable -->

## Issue link

https://linear.app/banx-gg/issue/BAN-2139/fe-banx-fix-sorting-by-apr-on-refi

## Vercel preview

https://banx-ui-git-bugfix-ban-2139-frakt.vercel.app/
