### PR TITLE
BAN-1968: Save selected collections in Search during navigating in app (till reload)

### DIFF
--- a/src/pages/BorrowPage/components/BorrowTable/hooks.ts
+++ b/src/pages/BorrowPage/components/BorrowTable/hooks.ts
@@ -24,6 +24,7 @@ import {
   useOffersOptimistic,
   useTableView,
 } from '@banx/store'
+import { createCollectionsStore } from '@banx/store/functions'
 import { getDialectAccessToken, trackPageEvent } from '@banx/utils'
 
 import { useCartState } from '../../cartState'
@@ -44,6 +45,8 @@ export interface UseBorrowTableProps {
   rawOffers: Record<string, Offer[]>
   maxLoanValueByMarket: Record<string, number>
 }
+
+const useCollectionsStore = createCollectionsStore()
 
 export const useBorrowTable = ({ nfts, rawOffers, maxLoanValueByMarket }: UseBorrowTableProps) => {
   const wallet = useWallet()
@@ -182,11 +185,11 @@ export const useBorrowTable = ({ nfts, rawOffers, maxLoanValueByMarket }: UseBor
     [addNft, findBestOffer, findOfferInCart, removeNft],
   )
 
-  const [selectedOptions, setSelectedOptions] = useState<string[]>([])
+  const { selectedCollections, setSelectedCollections } = useCollectionsStore()
 
   const [sortOption, setSortOption] = useState<SortOption>(DEFAULT_TABLE_SORT)
 
-  const filteredNfts = useFilteredNfts(tableNftsData, selectedOptions)
+  const filteredNfts = useFilteredNfts(tableNftsData, selectedCollections)
   const sortedNfts = useSortedNfts(filteredNfts, sortOption.value)
 
   const searchSelectOptions = useMemo(() => {
@@ -275,11 +278,11 @@ export const useBorrowTable = ({ nfts, rawOffers, maxLoanValueByMarket }: UseBor
           secondLabel: { key: 'numberOfNFTs' },
         },
         className: styles.searchSelect,
-        selectedOptions,
+        selectedOptions: selectedCollections,
         labels: ['Collection', 'Nfts'],
         onChange: (value: string[]) => {
           trackPageEvent('borrow', `filter`)
-          setSelectedOptions(value)
+          setSelectedCollections(value)
         },
       },
       sortParams: {

--- a/src/pages/BorrowPage/components/BorrowTable/hooks.ts
+++ b/src/pages/BorrowPage/components/BorrowTable/hooks.ts
@@ -24,7 +24,7 @@ import {
   useOffersOptimistic,
   useTableView,
 } from '@banx/store'
-import { createCollectionsStore } from '@banx/store/functions'
+import { createGlobalState } from '@banx/store/functions'
 import { getDialectAccessToken, trackPageEvent } from '@banx/utils'
 
 import { useCartState } from '../../cartState'
@@ -46,7 +46,7 @@ export interface UseBorrowTableProps {
   maxLoanValueByMarket: Record<string, number>
 }
 
-const useCollectionsStore = createCollectionsStore()
+const useCollectionsStore = createGlobalState<string[]>([])
 
 export const useBorrowTable = ({ nfts, rawOffers, maxLoanValueByMarket }: UseBorrowTableProps) => {
   const wallet = useWallet()
@@ -185,7 +185,7 @@ export const useBorrowTable = ({ nfts, rawOffers, maxLoanValueByMarket }: UseBor
     [addNft, findBestOffer, findOfferInCart, removeNft],
   )
 
-  const { selectedCollections, setSelectedCollections } = useCollectionsStore()
+  const [selectedCollections, setSelectedCollections] = useCollectionsStore()
 
   const [sortOption, setSortOption] = useState<SortOption>(DEFAULT_TABLE_SORT)
 

--- a/src/pages/BorrowPage/components/NotConnectedTable/hooks.ts
+++ b/src/pages/BorrowPage/components/NotConnectedTable/hooks.ts
@@ -8,25 +8,30 @@ import { createSolValueJSX } from '@banx/components/TableComponents'
 
 import { MarketPreview } from '@banx/api/core'
 import { useMarketsPreview } from '@banx/pages/LendPage/hooks'
+import { createCollectionsStore } from '@banx/store/functions'
 
 import { DEFAULT_SORT_OPTION } from './constants'
 
 import styles from './NotConnectedTable.module.less'
 
+const useCollectionsStore = createCollectionsStore()
+
 export const useNotConnectedBorrow = () => {
   const { marketsPreview, isLoading } = useMarketsPreview()
 
-  const [selectedMarkets, setSelectedMarkets] = useState<string[]>([])
+  const { selectedCollections, setSelectedCollections } = useCollectionsStore()
 
   const showEmptyList = !isLoading && !marketsPreview?.length
 
   const handleFilterChange = (filteredOptions: string[]) => {
-    setSelectedMarkets(filteredOptions)
+    setSelectedCollections(filteredOptions)
   }
 
   const filteredMarkets = useMemo(() => {
-    return marketsPreview.filter(({ collectionName }) => selectedMarkets.includes(collectionName))
-  }, [marketsPreview, selectedMarkets])
+    return marketsPreview.filter(({ collectionName }) =>
+      selectedCollections.includes(collectionName),
+    )
+  }, [marketsPreview, selectedCollections])
 
   const { sortedMarkets, sortParams } = useSortMarkets(
     filteredMarkets.length ? filteredMarkets : marketsPreview,
@@ -34,7 +39,7 @@ export const useNotConnectedBorrow = () => {
 
   const searchSelectParams: SearchSelectProps<MarketPreview> = {
     options: marketsPreview,
-    selectedOptions: selectedMarkets,
+    selectedOptions: selectedCollections,
     placeholder: 'Select a collection',
     labels: ['Collection', 'Liquidity'],
     optionKeys: {

--- a/src/pages/BorrowPage/components/NotConnectedTable/hooks.ts
+++ b/src/pages/BorrowPage/components/NotConnectedTable/hooks.ts
@@ -8,24 +8,20 @@ import { createSolValueJSX } from '@banx/components/TableComponents'
 
 import { MarketPreview } from '@banx/api/core'
 import { useMarketsPreview } from '@banx/pages/LendPage/hooks'
-import { createCollectionsStore } from '@banx/store/functions'
+import { createGlobalState } from '@banx/store/functions'
 
 import { DEFAULT_SORT_OPTION } from './constants'
 
 import styles from './NotConnectedTable.module.less'
 
-const useCollectionsStore = createCollectionsStore()
+const useCollectionsStore = createGlobalState<string[]>([])
 
 export const useNotConnectedBorrow = () => {
   const { marketsPreview, isLoading } = useMarketsPreview()
 
-  const { selectedCollections, setSelectedCollections } = useCollectionsStore()
+  const [selectedCollections, setSelectedCollections] = useCollectionsStore()
 
   const showEmptyList = !isLoading && !marketsPreview?.length
-
-  const handleFilterChange = (filteredOptions: string[]) => {
-    setSelectedCollections(filteredOptions)
-  }
 
   const filteredMarkets = useMemo(() => {
     return marketsPreview.filter(({ collectionName }) =>
@@ -51,7 +47,7 @@ export const useNotConnectedBorrow = () => {
         format: (value: number) => createSolValueJSX(value, 1e9),
       },
     },
-    onChange: handleFilterChange,
+    onChange: setSelectedCollections,
     className: styles.searchSelect,
   }
 

--- a/src/pages/DashboardPage/components/DashboardBorrowTab/hooks.ts
+++ b/src/pages/DashboardPage/components/DashboardBorrowTab/hooks.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useMemo } from 'react'
 
 import { useConnection, useWallet } from '@solana/wallet-adapter-react'
 import { filter, first, groupBy, includes, map } from 'lodash'
@@ -19,6 +19,7 @@ import { useBorrowNfts } from '@banx/pages/BorrowPage/hooks'
 import { useMarketsPreview } from '@banx/pages/LendPage/hooks'
 import { PATHS } from '@banx/router'
 import { useLoansOptimistic, useModal, useOffersOptimistic } from '@banx/store'
+import { createCollectionsStore } from '@banx/store/functions'
 import { calculateLoanValue, getDialectAccessToken, trackPageEvent } from '@banx/utils'
 
 import { useBorrowerStats } from '../../hooks'
@@ -144,26 +145,28 @@ export const useSingleBorrow = () => {
   return { borrow, nfts, isLoading, findBestOffer }
 }
 
+const useCollectionsStore = createCollectionsStore()
+
 const useFilteredMarketsAndNFTs = (marketsPreview: MarketPreview[], nfts: BorrowNft[]) => {
   const { connected } = useWallet()
 
-  const [selectedOptions, setSelectedOptions] = useState<string[]>([])
+  const { selectedCollections, setSelectedCollections } = useCollectionsStore()
 
   const filteredMarkets = useMemo(() => {
-    if (selectedOptions.length) {
+    if (selectedCollections.length) {
       return filter(marketsPreview, ({ collectionName }) =>
-        includes(selectedOptions, collectionName),
+        includes(selectedCollections, collectionName),
       )
     }
     return marketsPreview
-  }, [marketsPreview, selectedOptions])
+  }, [marketsPreview, selectedCollections])
 
   const filteredNFTs = useMemo(() => {
-    if (selectedOptions.length) {
-      return filter(nfts, ({ nft }) => includes(selectedOptions, nft.meta.collectionName))
+    if (selectedCollections.length) {
+      return filter(nfts, ({ nft }) => includes(selectedCollections, nft.meta.collectionName))
     }
     return nfts
-  }, [nfts, selectedOptions])
+  }, [nfts, selectedCollections])
 
   const searchSelectOptions = useMemo(() => {
     const nftsGroupedByCollection = groupBy(nfts, (nft) => nft.nft.meta.collectionName)
@@ -183,9 +186,9 @@ const useFilteredMarketsAndNFTs = (marketsPreview: MarketPreview[], nfts: Borrow
   }, [nfts, marketsPreview])
 
   const searchSelectParams = {
-    onChange: setSelectedOptions,
+    onChange: setSelectedCollections,
     options: connected ? searchSelectOptions : marketsPreview,
-    selectedOptions,
+    selectedOptions: selectedCollections,
     optionKeys: {
       labelKey: 'collectionName',
       imageKey: 'collectionImage',

--- a/src/pages/DashboardPage/components/DashboardBorrowTab/hooks.ts
+++ b/src/pages/DashboardPage/components/DashboardBorrowTab/hooks.ts
@@ -19,7 +19,7 @@ import { useBorrowNfts } from '@banx/pages/BorrowPage/hooks'
 import { useMarketsPreview } from '@banx/pages/LendPage/hooks'
 import { PATHS } from '@banx/router'
 import { useLoansOptimistic, useModal, useOffersOptimistic } from '@banx/store'
-import { createCollectionsStore } from '@banx/store/functions'
+import { createGlobalState } from '@banx/store/functions'
 import { calculateLoanValue, getDialectAccessToken, trackPageEvent } from '@banx/utils'
 
 import { useBorrowerStats } from '../../hooks'
@@ -145,12 +145,12 @@ export const useSingleBorrow = () => {
   return { borrow, nfts, isLoading, findBestOffer }
 }
 
-const useCollectionsStore = createCollectionsStore()
+const useCollectionsStore = createGlobalState<string[]>([])
 
 const useFilteredMarketsAndNFTs = (marketsPreview: MarketPreview[], nfts: BorrowNft[]) => {
   const { connected } = useWallet()
 
-  const { selectedCollections, setSelectedCollections } = useCollectionsStore()
+  const [selectedCollections, setSelectedCollections] = useCollectionsStore()
 
   const filteredMarkets = useMemo(() => {
     if (selectedCollections.length) {

--- a/src/pages/DashboardPage/components/DashboardLendTab/hooks.ts
+++ b/src/pages/DashboardPage/components/DashboardLendTab/hooks.ts
@@ -7,7 +7,7 @@ import { createPercentValueJSX } from '@banx/components/TableComponents'
 
 import { MarketPreview } from '@banx/api/core'
 import { useMarketsPreview } from '@banx/pages/LendPage/hooks'
-import { createCollectionsStore } from '@banx/store/functions'
+import { createGlobalState } from '@banx/store/functions'
 
 export const useDashboardLendTab = () => {
   const { marketsPreview } = useMarketsPreview()
@@ -20,10 +20,10 @@ export const useDashboardLendTab = () => {
   return { marketsPreview: sortedMarketsByOfferTvl, searchSelectParams }
 }
 
-const useCollectionsStore = createCollectionsStore()
+const useCollectionsStore = createGlobalState<string[]>([])
 
 const useFilteredMarkets = (marketsPreview: MarketPreview[]) => {
-  const { selectedCollections, setSelectedCollections } = useCollectionsStore()
+  const [selectedCollections, setSelectedCollections] = useCollectionsStore()
 
   const filteredMarkets = useMemo(() => {
     if (selectedCollections.length) {

--- a/src/pages/DashboardPage/components/DashboardLendTab/hooks.ts
+++ b/src/pages/DashboardPage/components/DashboardLendTab/hooks.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useMemo } from 'react'
 
 import { filter, includes } from 'lodash'
 
@@ -7,6 +7,7 @@ import { createPercentValueJSX } from '@banx/components/TableComponents'
 
 import { MarketPreview } from '@banx/api/core'
 import { useMarketsPreview } from '@banx/pages/LendPage/hooks'
+import { createCollectionsStore } from '@banx/store/functions'
 
 export const useDashboardLendTab = () => {
   const { marketsPreview } = useMarketsPreview()
@@ -19,22 +20,24 @@ export const useDashboardLendTab = () => {
   return { marketsPreview: sortedMarketsByOfferTvl, searchSelectParams }
 }
 
+const useCollectionsStore = createCollectionsStore()
+
 const useFilteredMarkets = (marketsPreview: MarketPreview[]) => {
-  const [selectedOptions, setSelectedOptions] = useState<string[]>([])
+  const { selectedCollections, setSelectedCollections } = useCollectionsStore()
 
   const filteredMarkets = useMemo(() => {
-    if (selectedOptions.length) {
+    if (selectedCollections.length) {
       return filter(marketsPreview, ({ collectionName }) =>
-        includes(selectedOptions, collectionName),
+        includes(selectedCollections, collectionName),
       )
     }
     return marketsPreview
-  }, [marketsPreview, selectedOptions])
+  }, [marketsPreview, selectedCollections])
 
   const searchSelectParams = {
-    onChange: setSelectedOptions,
+    onChange: setSelectedCollections,
     options: marketsPreview,
-    selectedOptions,
+    selectedOptions: selectedCollections,
     optionKeys: {
       labelKey: 'collectionName',
       valueKey: 'collectionName',

--- a/src/pages/LoansPage/components/LoansActiveTable/hooks/useFilteredLoans.ts
+++ b/src/pages/LoansPage/components/LoansActiveTable/hooks/useFilteredLoans.ts
@@ -3,11 +3,14 @@ import { useMemo, useState } from 'react'
 import { filter, size } from 'lodash'
 
 import { Loan } from '@banx/api/core'
+import { createCollectionsStore } from '@banx/store/functions'
 import { isLoanTerminating } from '@banx/utils'
+
+const useCollectionsStore = createCollectionsStore()
 
 export const useFilterLoans = (loans: Loan[]) => {
   const [isTerminationFilterEnabled, setTerminationFilterState] = useState(false)
-  const [selectedCollections, setSelectedCollections] = useState<string[]>([])
+  const { selectedCollections, setSelectedCollections } = useCollectionsStore()
 
   const toggleTerminationFilter = () => {
     setTerminationFilterState(!isTerminationFilterEnabled)

--- a/src/pages/LoansPage/components/LoansActiveTable/hooks/useFilteredLoans.ts
+++ b/src/pages/LoansPage/components/LoansActiveTable/hooks/useFilteredLoans.ts
@@ -3,14 +3,14 @@ import { useMemo, useState } from 'react'
 import { filter, size } from 'lodash'
 
 import { Loan } from '@banx/api/core'
-import { createCollectionsStore } from '@banx/store/functions'
+import { createGlobalState } from '@banx/store/functions'
 import { isLoanTerminating } from '@banx/utils'
 
-const useCollectionsStore = createCollectionsStore()
+const useCollectionsStore = createGlobalState<string[]>([])
 
 export const useFilterLoans = (loans: Loan[]) => {
   const [isTerminationFilterEnabled, setTerminationFilterState] = useState(false)
-  const { selectedCollections, setSelectedCollections } = useCollectionsStore()
+  const [selectedCollections, setSelectedCollections] = useCollectionsStore()
 
   const toggleTerminationFilter = () => {
     setTerminationFilterState(!isTerminationFilterEnabled)

--- a/src/pages/LoansPage/components/LoansHistoryTable/hooks/useBorrowerActivity.ts
+++ b/src/pages/LoansPage/components/LoansHistoryTable/hooks/useBorrowerActivity.ts
@@ -6,17 +6,20 @@ import { useInfiniteQuery } from '@tanstack/react-query'
 import { SortOption } from '@banx/components/SortDropdown'
 
 import { fetchBorrowerActivity } from '@banx/api/activity'
+import { createCollectionsStore } from '@banx/store/functions'
 
 import { DEFAULT_SORT_OPTION } from '../constants'
 
 const PAGINATION_LIMIT = 15
+
+const useCollectionsStore = createCollectionsStore()
 
 export const useBorrowerActivity = () => {
   const { publicKey } = useWallet()
   const publicKeyString = publicKey?.toBase58() || ''
 
   const [sortOption, setSortOption] = useState<SortOption>(DEFAULT_SORT_OPTION)
-  const [selectedCollections, setSelectedCollections] = useState<string[]>([])
+  const { selectedCollections, setSelectedCollections } = useCollectionsStore()
 
   const [sortBy, order] = sortOption.value.split('_')
 

--- a/src/pages/LoansPage/components/LoansHistoryTable/hooks/useBorrowerActivity.ts
+++ b/src/pages/LoansPage/components/LoansHistoryTable/hooks/useBorrowerActivity.ts
@@ -6,20 +6,20 @@ import { useInfiniteQuery } from '@tanstack/react-query'
 import { SortOption } from '@banx/components/SortDropdown'
 
 import { fetchBorrowerActivity } from '@banx/api/activity'
-import { createCollectionsStore } from '@banx/store/functions'
+import { createGlobalState } from '@banx/store/functions'
 
 import { DEFAULT_SORT_OPTION } from '../constants'
 
 const PAGINATION_LIMIT = 15
 
-const useCollectionsStore = createCollectionsStore()
+const useCollectionsStore = createGlobalState<string[]>([])
 
 export const useBorrowerActivity = () => {
   const { publicKey } = useWallet()
   const publicKeyString = publicKey?.toBase58() || ''
 
   const [sortOption, setSortOption] = useState<SortOption>(DEFAULT_SORT_OPTION)
-  const { selectedCollections, setSelectedCollections } = useCollectionsStore()
+  const [selectedCollections, setSelectedCollections] = useCollectionsStore()
 
   const [sortBy, order] = sortOption.value.split('_')
 

--- a/src/pages/OffersPage/components/ActiveTabContent/components/LoansTable/hooks/useLoansTable.ts
+++ b/src/pages/OffersPage/components/ActiveTabContent/components/LoansTable/hooks/useLoansTable.ts
@@ -14,6 +14,7 @@ import {
   isLoanAbleToTerminate,
   useLenderLoans,
 } from '@banx/pages/OffersPage'
+import { createCollectionsStore } from '@banx/store/functions'
 import { formatDecimal, isUnderWaterLoan } from '@banx/utils'
 
 import { DEFAULT_SORT_OPTION, SORT_OPTIONS, useSortedLoans } from './useSortedLoans'
@@ -128,9 +129,11 @@ const createSearchSelectParams = ({
   return searchSelectParams
 }
 
+const useCollectionsStore = createCollectionsStore()
+
 const useFilterLoans = (loans: Loan[]) => {
   const [isUnderwaterFilterActive, setIsUnderwaterFilterActive] = useState(false)
-  const [selectedCollections, setSelectedCollections] = useState<string[]>([])
+  const { selectedCollections, setSelectedCollections } = useCollectionsStore()
 
   const filteredLoansByCollection = useMemo(() => {
     if (selectedCollections.length) {

--- a/src/pages/OffersPage/components/ActiveTabContent/components/LoansTable/hooks/useLoansTable.ts
+++ b/src/pages/OffersPage/components/ActiveTabContent/components/LoansTable/hooks/useLoansTable.ts
@@ -14,7 +14,7 @@ import {
   isLoanAbleToTerminate,
   useLenderLoans,
 } from '@banx/pages/OffersPage'
-import { createCollectionsStore } from '@banx/store/functions'
+import { createGlobalState } from '@banx/store/functions'
 import { formatDecimal, isUnderWaterLoan } from '@banx/utils'
 
 import { DEFAULT_SORT_OPTION, SORT_OPTIONS, useSortedLoans } from './useSortedLoans'
@@ -129,11 +129,11 @@ const createSearchSelectParams = ({
   return searchSelectParams
 }
 
-const useCollectionsStore = createCollectionsStore()
+const useCollectionsStore = createGlobalState<string[]>([])
 
 const useFilterLoans = (loans: Loan[]) => {
   const [isUnderwaterFilterActive, setIsUnderwaterFilterActive] = useState(false)
-  const { selectedCollections, setSelectedCollections } = useCollectionsStore()
+  const [selectedCollections, setSelectedCollections] = useCollectionsStore()
 
   const filteredLoansByCollection = useMemo(() => {
     if (selectedCollections.length) {

--- a/src/pages/OffersPage/components/HistoryOffersTable/hooks/useLenderActivity.ts
+++ b/src/pages/OffersPage/components/HistoryOffersTable/hooks/useLenderActivity.ts
@@ -6,17 +6,20 @@ import { useInfiniteQuery } from '@tanstack/react-query'
 import { SortOption } from '@banx/components/SortDropdown'
 
 import { fetchLenderActivity } from '@banx/api/activity'
+import { createCollectionsStore } from '@banx/store/functions'
 
 import { DEFAULT_SORT_OPTION } from '../constants'
 
 const PAGINATION_LIMIT = 15
+
+const useCollectionsStore = createCollectionsStore()
 
 export const useLenderActivity = () => {
   const { publicKey } = useWallet()
   const publicKeyString = publicKey?.toBase58() || ''
 
   const [sortOption, setSortOption] = useState<SortOption>(DEFAULT_SORT_OPTION)
-  const [selectedCollections, setSelectedCollections] = useState<string[]>([])
+  const { selectedCollections, setSelectedCollections } = useCollectionsStore()
 
   const [sortBy, order] = sortOption.value.split('_')
 

--- a/src/pages/OffersPage/components/HistoryOffersTable/hooks/useLenderActivity.ts
+++ b/src/pages/OffersPage/components/HistoryOffersTable/hooks/useLenderActivity.ts
@@ -6,20 +6,20 @@ import { useInfiniteQuery } from '@tanstack/react-query'
 import { SortOption } from '@banx/components/SortDropdown'
 
 import { fetchLenderActivity } from '@banx/api/activity'
-import { createCollectionsStore } from '@banx/store/functions'
+import { createGlobalState } from '@banx/store/functions'
 
 import { DEFAULT_SORT_OPTION } from '../constants'
 
 const PAGINATION_LIMIT = 15
 
-const useCollectionsStore = createCollectionsStore()
+const useCollectionsStore = createGlobalState<string[]>([])
 
 export const useLenderActivity = () => {
   const { publicKey } = useWallet()
   const publicKeyString = publicKey?.toBase58() || ''
 
   const [sortOption, setSortOption] = useState<SortOption>(DEFAULT_SORT_OPTION)
-  const { selectedCollections, setSelectedCollections } = useCollectionsStore()
+  const [selectedCollections, setSelectedCollections] = useCollectionsStore()
 
   const [sortBy, order] = sortOption.value.split('_')
 

--- a/src/pages/OffersPage/components/OffersTabContent/hooks/useOffersTabContent.ts
+++ b/src/pages/OffersPage/components/OffersTabContent/hooks/useOffersTabContent.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useMemo } from 'react'
 
 import { useWallet } from '@solana/wallet-adapter-react'
 import { filter, first, groupBy, includes, map, sumBy } from 'lodash'
@@ -8,6 +8,7 @@ import { SearchSelectProps } from '@banx/components/SearchSelect'
 import { createSolValueJSX } from '@banx/components/TableComponents'
 
 import { PATHS } from '@banx/router'
+import { createCollectionsStore } from '@banx/store/functions'
 import { formatDecimal } from '@banx/utils'
 
 import { useSortedOffers } from './useSortedOffers'
@@ -19,13 +20,15 @@ type SearchSelectOption = {
   lent: number
 }
 
+const useCollectionsStore = createCollectionsStore()
+
 export const useOffersContent = () => {
   const { connected } = useWallet()
   const navigate = useNavigate()
 
   const { offers, updateOrAddOffer, isLoading } = useUserOffers()
 
-  const [selectedCollections, setSelectedCollections] = useState<string[]>([])
+  const { selectedCollections, setSelectedCollections } = useCollectionsStore()
 
   const filteredOffers = useMemo(() => {
     if (selectedCollections.length) {

--- a/src/pages/OffersPage/components/OffersTabContent/hooks/useOffersTabContent.ts
+++ b/src/pages/OffersPage/components/OffersTabContent/hooks/useOffersTabContent.ts
@@ -8,7 +8,7 @@ import { SearchSelectProps } from '@banx/components/SearchSelect'
 import { createSolValueJSX } from '@banx/components/TableComponents'
 
 import { PATHS } from '@banx/router'
-import { createCollectionsStore } from '@banx/store/functions'
+import { createGlobalState } from '@banx/store/functions'
 import { formatDecimal } from '@banx/utils'
 
 import { useSortedOffers } from './useSortedOffers'
@@ -20,7 +20,7 @@ type SearchSelectOption = {
   lent: number
 }
 
-const useCollectionsStore = createCollectionsStore()
+const useCollectionsStore = createGlobalState<string[]>([])
 
 export const useOffersContent = () => {
   const { connected } = useWallet()
@@ -28,7 +28,7 @@ export const useOffersContent = () => {
 
   const { offers, updateOrAddOffer, isLoading } = useUserOffers()
 
-  const { selectedCollections, setSelectedCollections } = useCollectionsStore()
+  const [selectedCollections, setSelectedCollections] = useCollectionsStore()
 
   const filteredOffers = useMemo(() => {
     if (selectedCollections.length) {

--- a/src/pages/RefinancePage/components/RefinanceTable/hooks/useRefinanceTable.ts
+++ b/src/pages/RefinancePage/components/RefinanceTable/hooks/useRefinanceTable.ts
@@ -7,7 +7,7 @@ import { SortOption } from '@banx/components/SortDropdown'
 
 import { Loan } from '@banx/api/core'
 import { useAuctionsLoans } from '@banx/pages/RefinancePage/hooks'
-import { createCollectionsStore } from '@banx/store/functions'
+import { createGlobalState } from '@banx/store/functions'
 
 import { DEFAULT_SORT_OPTION } from '../constants'
 import { useFilteredLoans } from './useFilteredLoans'
@@ -15,12 +15,12 @@ import { useSortedLoans } from './useSortedLoans'
 
 import styles from '../RefinanceTable.module.less'
 
-const useCollectionsStore = createCollectionsStore()
+const useCollectionsStore = createGlobalState<string[]>([])
 
 export const useRefinanceTable = () => {
   const { loans, isLoading } = useAuctionsLoans()
 
-  const { selectedCollections, setSelectedCollections } = useCollectionsStore()
+  const [selectedCollections, setSelectedCollections] = useCollectionsStore()
 
   const [sortOption, setSortOption] = useState<SortOption>(DEFAULT_SORT_OPTION)
 

--- a/src/pages/RefinancePage/components/RefinanceTable/hooks/useRefinanceTable.ts
+++ b/src/pages/RefinancePage/components/RefinanceTable/hooks/useRefinanceTable.ts
@@ -7,6 +7,7 @@ import { SortOption } from '@banx/components/SortDropdown'
 
 import { Loan } from '@banx/api/core'
 import { useAuctionsLoans } from '@banx/pages/RefinancePage/hooks'
+import { createCollectionsStore } from '@banx/store/functions'
 
 import { DEFAULT_SORT_OPTION } from '../constants'
 import { useFilteredLoans } from './useFilteredLoans'
@@ -14,14 +15,16 @@ import { useSortedLoans } from './useSortedLoans'
 
 import styles from '../RefinanceTable.module.less'
 
+const useCollectionsStore = createCollectionsStore()
+
 export const useRefinanceTable = () => {
   const { loans, isLoading } = useAuctionsLoans()
 
-  const [selectedOptions, setSelectedOptions] = useState<string[]>([])
+  const { selectedCollections, setSelectedCollections } = useCollectionsStore()
 
   const [sortOption, setSortOption] = useState<SortOption>(DEFAULT_SORT_OPTION)
 
-  const filteredLoans = useFilteredLoans(loans, selectedOptions)
+  const filteredLoans = useFilteredLoans(loans, selectedCollections)
   const sortedLoans = useSortedLoans(filteredLoans, sortOption.value)
 
   const searchSelectOptions = useMemo(() => {
@@ -43,9 +46,9 @@ export const useRefinanceTable = () => {
   const showEmptyList = !loans?.length && !isLoading
 
   const searchSelectParams = {
-    onChange: setSelectedOptions,
+    onChange: setSelectedCollections,
     options: searchSelectOptions,
-    selectedOptions,
+    selectedOptions: selectedCollections,
     optionKeys: {
       labelKey: 'collectionName',
       valueKey: 'collectionName',

--- a/src/store/functions.ts
+++ b/src/store/functions.ts
@@ -1,13 +1,25 @@
+import { isFunction } from 'lodash'
 import { create } from 'zustand'
 
-type CollectionsStore = {
-  selectedCollections: string[]
-  setSelectedCollections: (collections: string[]) => void
+type State<T> = {
+  value: T
+  setValue: (newValue: T | ((prevValue: T) => T)) => void
 }
 
-export const createCollectionsStore = () => {
-  return create<CollectionsStore>((set) => ({
-    selectedCollections: [],
-    setSelectedCollections: (collections) => set({ selectedCollections: collections }),
+export const createGlobalState = <T>(defaultValue?: T) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const useStore = create<State<any>>((set) => ({
+    value: defaultValue ?? undefined,
+    setValue: (newValue: T | ((prevValue: T) => T)) =>
+      set((state) => ({
+        value: isFunction(newValue) ? (newValue as (prevValue: T) => T)(state.value) : newValue,
+      })),
   }))
+
+  return () => {
+    const state = useStore((state) => state.value)
+    const setState = useStore((state) => state.setValue)
+
+    return [state, setState] as [State<T>['value'], State<T>['setValue']]
+  }
 }

--- a/src/store/functions.ts
+++ b/src/store/functions.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand'
+
+type CollectionsStore = {
+  selectedCollections: string[]
+  setSelectedCollections: (collections: string[]) => void
+}
+
+export const createCollectionsStore = () => {
+  return create<CollectionsStore>((set) => ({
+    selectedCollections: [],
+    setSelectedCollections: (collections) => set({ selectedCollections: collections }),
+  }))
+}


### PR DESCRIPTION
## Description

<!-- Describe your changes here -->

## Screenshots

<!-- If applicable -->

## Issue link

https://linear.app/banx-gg/issue/BAN-1968/fe-banx-save-selected-collections-in-search-during-navigating-in-app

## Vercel preview

https://banx-ui-git-feature-ban-1968-frakt.vercel.app/loans
