### PR TITLE
BAN-2179: Update tooltips text on loans, lend and offers pages

### DIFF
--- a/src/components/StatInfo/StatInfo.tsx
+++ b/src/components/StatInfo/StatInfo.tsx
@@ -1,5 +1,6 @@
 import { CSSProperties, FC, SVGProps } from 'react'
 
+import { TooltipPlacement } from 'antd/es/tooltip'
 import classNames from 'classnames'
 
 import Tooltip from '../Tooltip'
@@ -21,6 +22,7 @@ export interface StatsInfoProps {
   label?: string
   secondValue?: string | JSX.Element
   tooltipText?: string
+  tooltipPlacement?: TooltipPlacement
   valueType?: VALUES_TYPES
   decimalPlaces?: number
   divider?: number
@@ -33,6 +35,7 @@ export const StatInfo: FC<StatsInfoProps> = ({
   label,
   value,
   tooltipText,
+  tooltipPlacement,
   secondValue,
   valueType = VALUES_TYPES.SOLPRICE,
   decimalPlaces = 2,
@@ -54,7 +57,7 @@ export const StatInfo: FC<StatsInfoProps> = ({
     <div className={containerClasses}>
       <div className={styles.labelWrapper}>
         <span className={labelClasses}>{label}</span>
-        {tooltipText && <Tooltip title={tooltipText} />}
+        {tooltipText && <Tooltip title={tooltipText} placement={tooltipPlacement} />}
       </div>
       <span className={valueClasses} style={valueStyles}>
         {formattedValue}

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -5,8 +5,12 @@ import { Tooltip as AntdTooltip, TooltipProps as AntdTooltipProps } from 'antd'
 
 import styles from './Tooltip.module.less'
 
-const Tooltip: FC<PropsWithChildren<AntdTooltipProps>> = ({ children, ...props }) => (
-  <AntdTooltip {...props} arrowContent={null} placement="bottom">
+const Tooltip: FC<PropsWithChildren<AntdTooltipProps>> = ({
+  children,
+  placement = 'bottom',
+  ...props
+}) => (
+  <AntdTooltip {...props} arrowContent={null} placement={placement}>
     {children || <InfoCircleOutlined className={styles.icon} />}
   </AntdTooltip>
 )

--- a/src/pages/LendPage/components/MarketOverviewInfo/MarketOverviewInfo.tsx
+++ b/src/pages/LendPage/components/MarketOverviewInfo/MarketOverviewInfo.tsx
@@ -34,7 +34,12 @@ export const MarketMainInfo: FC<{ market: MarketPreview }> = ({ market }) => {
         </div>
 
         <div className={styles.mainInfoStats}>
-          <StatInfo label="Floor" value={collectionFloor} divider={1e9} />
+          <StatInfo
+            label="Floor"
+            tooltipText="Lowest listing price on marketplaces, excluding taker royalties and fees"
+            value={collectionFloor}
+            divider={1e9}
+          />
           <StatInfo
             label="Top offer"
             value={`${formattedMaxOffer}◎`}

--- a/src/pages/LoansPage/components/LoansActiveTable/Summary.tsx
+++ b/src/pages/LoansPage/components/LoansActiveTable/Summary.tsx
@@ -64,7 +64,7 @@ export const Summary: FC<SummaryProps> = ({
           divider={1e9}
         />
         <StatInfo label="Accrued interest" value={totalUnpaidAccruedInterest} divider={1e9} />
-        <StatInfo label="Weekly fee" value={totalWeeklyFee} divider={1e9} />
+        <StatInfo label="Weekly interest" value={totalWeeklyFee} divider={1e9} />
         <StatInfo
           label="Weighted apr"
           value={calcWeightedApr(selectedLoans)}

--- a/src/pages/LoansPage/components/LoansActiveTable/TableCells/cells.tsx
+++ b/src/pages/LoansPage/components/LoansActiveTable/TableCells/cells.tsx
@@ -56,7 +56,7 @@ export const DebtCell: FC<CellProps> = ({ loan }) => {
       <TooltipRow label="Repaid" value={totalRepaidAmount} />
       <TooltipRow label="Accrued interest" value={totalAccruedInterest + upfrontFee} />
       <TooltipRow label="Upfront fee" value={upfrontFee} />
-      <TooltipRow label="Est. weekly fee" value={weeklyFee} />
+      <TooltipRow label="Est. weekly interest" value={weeklyFee} />
     </div>
   )
 

--- a/src/pages/LoansPage/components/LoansActiveTable/columns.tsx
+++ b/src/pages/LoansPage/components/LoansActiveTable/columns.tsx
@@ -51,7 +51,12 @@ export const getTableColumns = ({
     },
     {
       key: 'debt',
-      title: <HeaderCell label="Debt" />,
+      title: (
+        <HeaderCell
+          label="Debt"
+          tooltipText="Hover over the debt balance of your loans below to view a breakdown of your principal, interest and repayments (if any) to date"
+        />
+      ),
       render: (loan) => <DebtCell loan={loan} />,
     },
     {

--- a/src/pages/LoansPage/components/LoansHeader/LoansHeader.tsx
+++ b/src/pages/LoansPage/components/LoansHeader/LoansHeader.tsx
@@ -31,7 +31,12 @@ const LoansHeader: FC<LoansHeaderProps> = ({ loans }) => {
     >
       <AdditionalStat label="Loans" value={numberOfLoans} valueType={VALUES_TYPES.STRING} />
       <AdditionalStat label="Borrowed" value={totalBorrowed} divider={1e9} />
-      <AdditionalStat label="Weekly fee" value={totalWeeklyFee} divider={1e9} />
+      <AdditionalStat
+        label="Weekly interest"
+        tooltipText="Expected weekly interest on your loans. Interest is added to your debt balance"
+        value={totalWeeklyFee}
+        divider={1e9}
+      />
       <SeparateStatsLine />
       <MainStat label="Debt" value={totalDebt} divider={1e9} />
     </PageHeaderBackdrop>

--- a/src/pages/LoansPage/components/LoansHeader/LoansHeader.tsx
+++ b/src/pages/LoansPage/components/LoansHeader/LoansHeader.tsx
@@ -34,6 +34,7 @@ const LoansHeader: FC<LoansHeaderProps> = ({ loans }) => {
       <AdditionalStat
         label="Weekly interest"
         tooltipText="Expected weekly interest on your loans. Interest is added to your debt balance"
+        tooltipPlacement="bottomLeft"
         value={totalWeeklyFee}
         divider={1e9}
       />

--- a/src/pages/OffersPage/components/OffersTabContent/components/OfferCard/components.tsx
+++ b/src/pages/OffersPage/components/OffersTabContent/components/OfferCard/components.tsx
@@ -32,7 +32,12 @@ export const MainOfferOverview: FC<MainOfferOverviewProps> = ({ offer }) => {
           {tensorSlug && <TensorLink className={styles.tensorLink} slug={tensorSlug} />}
         </div>
         <div className={styles.mainOfferStats}>
-          <StatInfo label="Floor" value={collectionFloor} divider={1e9} />
+          <StatInfo
+            label="Floor"
+            tooltipText="Lowest listing price on marketplaces, excluding taker royalties and fees"
+            value={collectionFloor}
+            divider={1e9}
+          />
           <StatInfo
             label="Top offer"
             value={bestOffer}


### PR DESCRIPTION
## Description

 Update tooltips text on loans, lend and offers pages

## Screenshots

<!-- If applicable -->

## Issue link

https://linear.app/banx-gg/issue/BAN-2179/fe-banx-rename-weekly-fee-to-weekly-interest-and-add-tooltips

## Vercel preview

https://banx-ui-git-feature-ban-2179-frakt.vercel.app/
