### PR TITLE
BAN-2188: Add boost (player pts) into wallet modal for each wallet

### DIFF
--- a/src/api/user/requests.ts
+++ b/src/api/user/requests.ts
@@ -117,6 +117,7 @@ export const fetchLinkedWallets: FetchLinkedWallets = async ({ walletPublicKey }
       borrowerRank: 0,
       lenderPoints: 0,
       lenderRank: 0,
+      boost: 0,
     },
   ]
 
@@ -158,6 +159,7 @@ export const linkWallet: LinkWallet = async ({ linkedWalletJwt, wallet, signatur
       borrowerRank: 0,
       lenderPoints: 0,
       lenderRank: 0,
+      boost: 0,
     }
     return errorResponse
   }

--- a/src/api/user/types.ts
+++ b/src/api/user/types.ts
@@ -79,6 +79,7 @@ export type LinkedWalletPoints = {
   borrowerRank: number
   lenderPoints: number
   lenderRank: number
+  boost: number
 }
 
 export type LinkedWallet = {

--- a/src/pages/LeaderboardPage/components/LinkWalletsModal/LinkWalletsModal.module.less
+++ b/src/pages/LeaderboardPage/components/LinkWalletsModal/LinkWalletsModal.module.less
@@ -59,9 +59,10 @@
 }
 
 .linkedWalletsTable {
-  width: 100%;
   border-collapse: collapse;
   font: var(--body-text-md);
+  min-width: 400px;
+  width: 100%;
 
   @media screen and (max-width: 640px) {
     font: var(--body-text-sm);
@@ -149,6 +150,14 @@
       left: 4px;
     }
   }
+}
+
+//TODO: Use "important-text-md" when variables will be updated 
+.linkedWalletBoost {
+  color: var(--pure-purple);
+  font-family: var(--font-family-chakra);
+  font-weight: 700;
+  font-size: 14px;
 }
 
 .linkedWalletRightContainer {

--- a/src/pages/LeaderboardPage/components/LinkWalletsModal/components/LinkedWalletsTable.tsx
+++ b/src/pages/LeaderboardPage/components/LinkWalletsModal/components/LinkedWalletsTable.tsx
@@ -30,6 +30,7 @@ export const LinkedWalletsTable: FC = () => {
             <th>Wallet</th>
             <th>Borrower pts</th>
             <th>Lender pts</th>
+            <th>Boost</th>
             <th></th>
           </tr>
         </thead>
@@ -82,6 +83,7 @@ const LinkedWalletItem: FC<LinkedWalletProps> = ({ linkedWallet, isActive = fals
       </td>
       <td>{formatNumbersWithCommas(linkedWallet.borrowerPoints?.toFixed(0))}</td>
       <td>{formatNumbersWithCommas(linkedWallet.lenderPoints?.toFixed(0))}</td>
+      <td className={styles.linkedWalletBoost}>{formatNumbersWithCommas(linkedWallet.boost)}x</td>
       <td className={styles.linkedWalletRightContainer}>
         {isMainWallet && <House className={styles.houseIco} />}
         {onUnlink && !isUnlinking && (

--- a/src/pages/LeaderboardPage/components/LinkWalletsModal/hooks.ts
+++ b/src/pages/LeaderboardPage/components/LinkWalletsModal/hooks.ts
@@ -86,7 +86,7 @@ export const useLinkWalletsModal = () => {
       })
 
       if (savedLinkingData.linkedWallets) {
-        const { borrowerPoints, borrowerRank, lenderPoints, lenderRank } = linkResponse
+        const { borrowerPoints, borrowerRank, lenderPoints, lenderRank, boost } = linkResponse
 
         setLinkedWalletsOptimistic(publicKey.toBase58(), [
           ...savedLinkingData.linkedWallets,
@@ -97,6 +97,7 @@ export const useLinkWalletsModal = () => {
             borrowerRank: borrowerRank ?? 0,
             lenderPoints: lenderPoints ?? 0,
             lenderRank: lenderRank ?? 0,
+            boost: boost ?? 0,
           },
         ])
       }


### PR DESCRIPTION
## Description

Add boost (player pts) into wallet modal for each wallet

## Screenshots

<!-- If applicable -->

## Issue link

https://linear.app/banx-gg/issue/BAN-2188/fe-add-boost-player-pts-into-wallet-modal-for-each-wallet

## Vercel preview

https://banx-ui-git-feature-ban-2188-frakt.vercel.app/