### PR TITLE
BAN-2302:  Disable subscribe button if no staked nfts or tokens

### DIFF
--- a/src/pages/AdventuresPage/components/AdventuresList/AdventuresList.tsx
+++ b/src/pages/AdventuresPage/components/AdventuresList/AdventuresList.tsx
@@ -2,6 +2,7 @@ import React, { FC, useMemo } from 'react'
 
 import { useConnection, useWallet } from '@solana/wallet-adapter-react'
 import classNames from 'classnames'
+import { BN } from 'fbonds-core'
 import { BANX_ADVENTURE_GAP } from 'fbonds-core/lib/fbond-protocol/constants'
 import { BanxSubscribeAdventureOptimistic } from 'fbonds-core/lib/fbond-protocol/functions/banxStaking/banxAdventure'
 import { BanxAdventureSubscriptionState } from 'fbonds-core/lib/fbond-protocol/types'
@@ -84,7 +85,8 @@ const AdventuresCard: FC<AdventuresCardProps> = ({
   ).toFixed(2)
 
   const isParticipating =
-    !!banxStake?.banxTokenStake?.tokensStaked || !!banxStake?.banxTokenStake?.banxNftsStakedQuantity
+    banxStake?.banxTokenStake?.tokensStaked !== '0' &&
+    banxStake?.banxTokenStake?.banxNftsStakedQuantity !== '0'
 
   const isSubscribed =
     banxSubscription?.adventureSubscriptionState === BanxAdventureSubscriptionState.Active

--- a/src/pages/AdventuresPage/components/AdventuresList/AdventuresList.tsx
+++ b/src/pages/AdventuresPage/components/AdventuresList/AdventuresList.tsx
@@ -85,7 +85,7 @@ const AdventuresCard: FC<AdventuresCardProps> = ({
   ).toFixed(2)
 
   const isParticipating =
-    banxStake?.banxTokenStake?.tokensStaked !== '0' &&
+    banxStake?.banxTokenStake?.tokensStaked !== '0' ||
     banxStake?.banxTokenStake?.banxNftsStakedQuantity !== '0'
 
   const isSubscribed =


### PR DESCRIPTION
## Issue link

https://linear.app/banx-gg/issue/BAN-2302/fe-banx-disable-subscribe-button-if-no-staked-nfts-or-tokens

## Vercel preview

https://banx-ui-git-fix-staking-frakt.vercel.app/
