### PR TITLE
BAN-2311: Remove rewards from wallet modal

### DIFF
--- a/src/components/WalletModal/components.tsx
+++ b/src/components/WalletModal/components.tsx
@@ -2,18 +2,15 @@ import { FC } from 'react'
 
 import { useWallet } from '@solana/wallet-adapter-react'
 import classNames from 'classnames'
-import { sumBy } from 'lodash'
 
 import { useDiscordUser } from '@banx/hooks'
-import { ChangeWallet, Copy, Logo, SignOut } from '@banx/icons'
+import { ChangeWallet, Copy, SignOut } from '@banx/icons'
 import { useIsLedger } from '@banx/store'
-import { copyToClipboard, formatNumbersWithCommas, shortenAddress } from '@banx/utils'
+import { copyToClipboard, shortenAddress } from '@banx/utils'
 
 import Checkbox from '../Checkbox'
-import { StatInfo, VALUES_TYPES } from '../StatInfo'
 import UserAvatar from '../UserAvatar'
 import { iconComponents } from './constants'
-import { useFetchUserRewards } from './hooks'
 
 import styles from './WalletModal.module.less'
 
@@ -38,30 +35,6 @@ const UserGeneralInfo = () => {
   )
 }
 
-const UserBalance = () => {
-  const { publicKey } = useWallet()
-
-  const publicKeyString = publicKey?.toBase58() || ''
-
-  const { data } = useFetchUserRewards(publicKeyString)
-
-  const totalRewards = sumBy(data?.sources?.map(([, value]) => value))
-  const displayRewardsValue = formatNumbersWithCommas((totalRewards / 1e9)?.toFixed(0) || 0)
-
-  return (
-    <div className={styles.userBalanceContainer}>
-      <StatInfo
-        flexType="row"
-        label="Rewards"
-        value={displayRewardsValue}
-        classNamesProps={{ container: styles.userRewards, value: styles.userLockedTokens }}
-        valueType={VALUES_TYPES.STRING}
-        icon={Logo}
-      />
-    </div>
-  )
-}
-
 interface UserInfoProps {
   onChangeWallet: () => void
   disconnect: () => Promise<void>
@@ -70,7 +43,6 @@ interface UserInfoProps {
 export const UserInfo: FC<UserInfoProps> = ({ onChangeWallet, disconnect }) => (
   <div className={styles.userInfoContainer}>
     <UserGeneralInfo />
-    <UserBalance />
     <div className={styles.buttonsWrapper}>
       <div className={styles.changeWalletButton} onClick={onChangeWallet}>
         <ChangeWallet />

--- a/src/constants/loans.ts
+++ b/src/constants/loans.ts
@@ -1,10 +1,4 @@
 export const MARKETS_WITH_CUSTOM_APR: Record<string, number> = {
   ['oeN7bBJAjFqnvFwALPBazEFJeTi9F6tLvKHhuoJjSkk']: 3380, //? ONE collection PUBLIC market
   ['2RSYRoqZ2bKnKGeLtGFyTmDLNEaV9Z9zhmZd5qXxAsr9']: 3380, //? ONE collection PRIVATE market
-
-  ['HpzJyoNhfwbtco6Z8ghtqf85cDwFpYWqkBo1X1ah8cwX']: 3380, //? Lifinity collection PUBLIC market
-  ['FFhTvrX3L3QJwZrbjb2BQxV1PXccXfW8cWpz7VVyD3nM']: 3380, //? Lifinity collection PRIVATE market
-
-  ['4XNFTPM6v5fDySb3nsmfcozc2Cf12Xsmvy3nufNfoWUS']: 3380, //? Cloak DAO collection PUBLIC market
-  ['HuKW1yTTLFcTdt9cKvGxSBjYhmQgyAXpgyEwqdxAZS7e']: 3380, //? Cloak DAO collection PRIVATE market
 }

--- a/src/constants/loans.ts
+++ b/src/constants/loans.ts
@@ -1,4 +1,10 @@
 export const MARKETS_WITH_CUSTOM_APR: Record<string, number> = {
   ['oeN7bBJAjFqnvFwALPBazEFJeTi9F6tLvKHhuoJjSkk']: 3380, //? ONE collection PUBLIC market
   ['2RSYRoqZ2bKnKGeLtGFyTmDLNEaV9Z9zhmZd5qXxAsr9']: 3380, //? ONE collection PRIVATE market
+
+  ['HpzJyoNhfwbtco6Z8ghtqf85cDwFpYWqkBo1X1ah8cwX']: 3380, //? Lifinity collection PUBLIC market
+  ['FFhTvrX3L3QJwZrbjb2BQxV1PXccXfW8cWpz7VVyD3nM']: 3380, //? Lifinity collection PRIVATE market
+
+  ['4XNFTPM6v5fDySb3nsmfcozc2Cf12Xsmvy3nufNfoWUS']: 3380, //? Cloak DAO collection PUBLIC market
+  ['HuKW1yTTLFcTdt9cKvGxSBjYhmQgyAXpgyEwqdxAZS7e']: 3380, //? Cloak DAO collection PRIVATE market
 }

--- a/src/pages/AdventuresPage/components/AdventuresList/AdventuresList.tsx
+++ b/src/pages/AdventuresPage/components/AdventuresList/AdventuresList.tsx
@@ -2,7 +2,6 @@ import React, { FC, useMemo } from 'react'
 
 import { useConnection, useWallet } from '@solana/wallet-adapter-react'
 import classNames from 'classnames'
-import { BN } from 'fbonds-core'
 import { BANX_ADVENTURE_GAP } from 'fbonds-core/lib/fbond-protocol/constants'
 import { BanxSubscribeAdventureOptimistic } from 'fbonds-core/lib/fbond-protocol/functions/banxStaking/banxAdventure'
 import { BanxAdventureSubscriptionState } from 'fbonds-core/lib/fbond-protocol/types'


### PR DESCRIPTION
## Description

Remove rewards from wallet modal

## Screenshots

<img width="377" alt="image" src="https://github.com/frakt-solana/banx-ui/assets/60342317/0cae6956-d24f-4415-a7da-e70866fd7bd8">

## Issue link

https://linear.app/banx-gg/issue/BAN-2311/fe-removehide-rewards-from-wallet-modal

## Vercel preview

https://banx-ui-git-feature-ban-2311-frakt.vercel.app/
