### PR TITLE
BAN-2346:  added amountOfTokensHarvested in adventures history

### DIFF
--- a/src/pages/AdventuresPage/components/AdventuresList/AdventuresList.tsx
+++ b/src/pages/AdventuresPage/components/AdventuresList/AdventuresList.tsx
@@ -119,7 +119,7 @@ const AdventuresCard: FC<AdventuresCardProps> = ({
             banxAdventure={banxAdventure}
           />
         )}
-        {isEnded && wallet.connected && (
+        {isEnded && (
           <AdventureEndedRewardsResult
             banxAdventureSubscription={banxAdventureSubscription}
             banxAdventure={banxAdventure}

--- a/src/pages/AdventuresPage/components/AdventuresList/components.tsx
+++ b/src/pages/AdventuresPage/components/AdventuresList/components.tsx
@@ -223,21 +223,19 @@ export const AdventureEndedRewardsResult: FC<AdventureEndedRewardsResultProps> =
     )
   }, [banxAdventure, banxAdventureSubscription, isSubscribed, connected])
 
-  const amountOfTokensHarvested = useMemo(() => {
-    return banxTokenBNToFixed(banxAdventure.amountOfTokensHarvested, 0)
-  }, [banxAdventure.amountOfTokensHarvested])
+  const amountOfTokensHarvested = banxTokenBNToFixed(banxAdventure.amountOfTokensHarvested, 0)
+  const title = connected ? 'You received' : 'Total distributed'
+  const value = connected
+    ? formatNumbersWithCommas(rewards)
+    : formatNumbersWithCommas(amountOfTokensHarvested)
 
   return (
     <div className={styles.endedRewards}>
       <div className={styles.endedRewardsValue}>
-        <p>
-          {connected
-            ? formatNumbersWithCommas(rewards)
-            : formatNumbersWithCommas(amountOfTokensHarvested)}
-        </p>
+        <p>{value}</p>
         <BanxLogo className={styles.endedRewardsBanxLogo} />
       </div>
-      <p className={styles.endedRewardsText}> {connected ? 'You received' : 'Total distributed'}</p>
+      <p className={styles.endedRewardsText}>{title}</p>
     </div>
   )
 }

--- a/src/pages/AdventuresPage/components/AdventuresList/components.tsx
+++ b/src/pages/AdventuresPage/components/AdventuresList/components.tsx
@@ -213,7 +213,13 @@ export const AdventureEndedRewardsResult: FC<AdventureEndedRewardsResultProps> =
   const isSubscribed = !!banxAdventureSubscription && checkIsSubscribed(banxAdventureSubscription)
 
   const rewards: string = useMemo(() => {
-    if (!banxAdventureSubscription || !isSubscribed || !connected) return '0'
+    if (!connected) {
+      return banxTokenBNToFixed(banxAdventure.amountOfTokensHarvested, 0)
+    }
+
+    if (!banxAdventureSubscription || !isSubscribed) {
+      return '0'
+    }
 
     return banxTokenBNToFixed(
       calculateAdventureRewards([
@@ -223,16 +229,12 @@ export const AdventureEndedRewardsResult: FC<AdventureEndedRewardsResultProps> =
     )
   }, [banxAdventure, banxAdventureSubscription, isSubscribed, connected])
 
-  const amountOfTokensHarvested = banxTokenBNToFixed(banxAdventure.amountOfTokensHarvested, 0)
   const title = connected ? 'You received' : 'Total distributed'
-  const value = connected
-    ? formatNumbersWithCommas(rewards)
-    : formatNumbersWithCommas(amountOfTokensHarvested)
 
   return (
     <div className={styles.endedRewards}>
       <div className={styles.endedRewardsValue}>
-        <p>{value}</p>
+        <p>{formatNumbersWithCommas(rewards)}</p>
         <BanxLogo className={styles.endedRewardsBanxLogo} />
       </div>
       <p className={styles.endedRewardsText}>{title}</p>

--- a/src/pages/AdventuresPage/components/AdventuresList/components.tsx
+++ b/src/pages/AdventuresPage/components/AdventuresList/components.tsx
@@ -1,5 +1,6 @@
 import { FC, useMemo } from 'react'
 
+import { useWallet } from '@solana/wallet-adapter-react'
 import classNames from 'classnames'
 import { BanxAdventureSubscriptionState } from 'fbonds-core/lib/fbond-protocol/types'
 
@@ -208,10 +209,11 @@ export const AdventureEndedRewardsResult: FC<AdventureEndedRewardsResultProps> =
   banxAdventure,
   banxAdventureSubscription,
 }) => {
+  const { connected } = useWallet()
   const isSubscribed = !!banxAdventureSubscription && checkIsSubscribed(banxAdventureSubscription)
 
   const rewards: string = useMemo(() => {
-    if (!banxAdventureSubscription || !isSubscribed) return '0'
+    if (!banxAdventureSubscription || !isSubscribed || !connected) return '0'
 
     return banxTokenBNToFixed(
       calculateAdventureRewards([
@@ -219,15 +221,23 @@ export const AdventureEndedRewardsResult: FC<AdventureEndedRewardsResultProps> =
       ]),
       0,
     )
-  }, [banxAdventure, banxAdventureSubscription, isSubscribed])
+  }, [banxAdventure, banxAdventureSubscription, isSubscribed, connected])
+
+  const amountOfTokensHarvested = useMemo(() => {
+    return banxTokenBNToFixed(banxAdventure.amountOfTokensHarvested, 0)
+  }, [banxAdventure.amountOfTokensHarvested])
 
   return (
     <div className={styles.endedRewards}>
       <div className={styles.endedRewardsValue}>
-        <p>{formatNumbersWithCommas(rewards)}</p>
+        <p>
+          {connected
+            ? formatNumbersWithCommas(rewards)
+            : formatNumbersWithCommas(amountOfTokensHarvested)}
+        </p>
         <BanxLogo className={styles.endedRewardsBanxLogo} />
       </div>
-      <p className={styles.endedRewardsText}>You received</p>
+      <p className={styles.endedRewardsText}> {connected ? 'You received' : 'Total distributed'}</p>
     </div>
   )
 }


### PR DESCRIPTION
added amountOfTokensHarvested if wallet not connected in adventures history

## Description

<!-- If applicable -->

https://linear.app/banx-gg/issue/BAN-2346/fe-implement-total-distirbuted-in-adventures-history

<!-- Insert link here -->

## Vercel preview

https://banx-ui-git-ban-2346-total-distirbuted-adventures-history-frakt.vercel.app/

