### PR TITLE
BAN-2345: Implement confirmation timeout (#733)

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "react-router-dom": "^6.14.2",
     "react-text-transition": "^3.1.0",
     "react-virtuoso": "^4.6.2",
-    "solana-transactions-executor": "2.0.1",
+    "solana-transactions-executor": "2.2.4",
     "zod": "^3.21.4",
     "zustand": "^4.3.9"
   },

--- a/src/components/PlaceOfferSection/hooks/useOfferTransactions.ts
+++ b/src/components/PlaceOfferSection/hooks/useOfferTransactions.ts
@@ -3,6 +3,7 @@ import { uniqueId } from 'lodash'
 import { TxnExecutor } from 'solana-transactions-executor'
 
 import { Offer } from '@banx/api/core'
+import { TXN_EXECUTOR_CONFIRM_OPTIONS } from '@banx/constants'
 import { usePriorityFees } from '@banx/store'
 import { createWalletInstance, defaultTxnErrorHandler } from '@banx/transactions'
 import {
@@ -12,8 +13,8 @@ import {
 } from '@banx/transactions/bonds'
 import {
   destroySnackbar,
+  enqueueConfirmationError,
   enqueueSnackbar,
-  enqueueTranactionError,
   enqueueTransactionSent,
   enqueueWaitingConfirmation,
 } from '@banx/utils'
@@ -52,10 +53,16 @@ export const useOfferTransactions = ({
       priorityFeeLevel: priorityLevel,
     }
 
-    await new TxnExecutor(makeCreateBondingOfferAction, {
-      wallet: createWalletInstance(wallet),
-      connection,
-    })
+    await new TxnExecutor(
+      makeCreateBondingOfferAction,
+      {
+        wallet: createWalletInstance(wallet),
+        connection,
+      },
+      {
+        confirmOptions: TXN_EXECUTOR_CONFIRM_OPTIONS,
+      },
+    )
       .addTransactionParam(txnParam)
       .on('sentSome', (results) => {
         results.forEach(({ signature }) => enqueueTransactionSent(signature))
@@ -67,7 +74,9 @@ export const useOfferTransactions = ({
         destroySnackbar(loadingSnackbarId)
 
         if (failed.length) {
-          return enqueueTranactionError()
+          return failed.forEach(({ signature, reason }) =>
+            enqueueConfirmationError(signature, reason),
+          )
         }
 
         return confirmed.forEach(({ result, signature }) => {
@@ -107,10 +116,16 @@ export const useOfferTransactions = ({
       priorityFeeLevel: priorityLevel,
     }
 
-    await new TxnExecutor(makeUpdateBondingOfferAction, {
-      wallet: createWalletInstance(wallet),
-      connection,
-    })
+    await new TxnExecutor(
+      makeUpdateBondingOfferAction,
+      {
+        wallet: createWalletInstance(wallet),
+        connection,
+      },
+      {
+        confirmOptions: TXN_EXECUTOR_CONFIRM_OPTIONS,
+      },
+    )
       .addTransactionParam(txnParam)
       .on('sentSome', (results) => {
         results.forEach(({ signature }) => enqueueTransactionSent(signature))
@@ -122,7 +137,9 @@ export const useOfferTransactions = ({
         destroySnackbar(loadingSnackbarId)
 
         if (failed.length) {
-          return enqueueTranactionError()
+          return failed.forEach(({ signature, reason }) =>
+            enqueueConfirmationError(signature, reason),
+          )
         }
 
         return confirmed.forEach(({ result, signature }) => {
@@ -153,7 +170,13 @@ export const useOfferTransactions = ({
 
     const loadingSnackbarId = uniqueId()
 
-    new TxnExecutor(makeRemoveOfferAction, { wallet: createWalletInstance(wallet), connection })
+    new TxnExecutor(
+      makeRemoveOfferAction,
+      { wallet: createWalletInstance(wallet), connection },
+      {
+        confirmOptions: TXN_EXECUTOR_CONFIRM_OPTIONS,
+      },
+    )
       .addTransactionParam({ optimisticOffer, priorityFeeLevel: priorityLevel })
       .on('sentSome', (results) => {
         results.forEach(({ signature }) => enqueueTransactionSent(signature))
@@ -165,7 +188,9 @@ export const useOfferTransactions = ({
         destroySnackbar(loadingSnackbarId)
 
         if (failed.length) {
-          return enqueueTranactionError()
+          return failed.forEach(({ signature, reason }) =>
+            enqueueConfirmationError(signature, reason),
+          )
         }
 
         return confirmed.forEach(({ result, signature }) => {

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -1,7 +1,14 @@
+export const RPC_HELIUS =
+  'https://mainnet.helius-rpc.com/?api-key=d283785c-6f2c-43de-b460-a938327fc6f5'
+export const RPC_QUICKNODE =
+  'https://smart-powerful-knowledge.solana-mainnet.discover.quiknode.pro/887d337202841789c5a6d168e1c3b7809e45d268/'
+export const RPC_HELLOMOON = 'https://rpc.hellomoon.io/51e91377-d146-4f74-bf41-c4b11d42cebe'
+export const RPC_PUBLIC = 'https://solana-mainnet.rpc.extrnode.com/'
+
 export const RPC_ENDPOINTS = [
   process.env.RPC_LOCALHOST || '',
-  'https://mainnet.helius-rpc.com/?api-key=d283785c-6f2c-43de-b460-a938327fc6f5',
-  'https://smart-powerful-knowledge.solana-mainnet.discover.quiknode.pro/887d337202841789c5a6d168e1c3b7809e45d268/',
-  'https://solana-mainnet.rpc.extrnode.com/',
-  'https://rpc.hellomoon.io/51e91377-d146-4f74-bf41-c4b11d42cebe',
+  RPC_HELIUS,
+  RPC_HELLOMOON,
+  RPC_QUICKNODE,
+  RPC_PUBLIC,
 ].filter(Boolean)

--- a/src/constants/transactions.ts
+++ b/src/constants/transactions.ts
@@ -1,13 +1,9 @@
-import { web3 } from 'fbonds-core'
+import { ExecutorOptions } from 'solana-transactions-executor'
 
-export const TXN_EXECUTOR_CONFIRM_OPTIONS: {
-  skipPreflight: boolean
-  maxRetries: number
-  commitment: web3.Commitment
-  preflightCommitment: web3.Commitment
-} = {
+export const TXN_EXECUTOR_CONFIRM_OPTIONS: ExecutorOptions['confirmOptions'] = {
   skipPreflight: true,
-  maxRetries: 1,
-  commitment: 'confirmed',
-  preflightCommitment: 'confirmed',
+  maxRetries: 0,
+  commitment: 'processed',
+  preflightCommitment: 'processed',
+  confirmationTimeout: 15,
 }

--- a/src/pages/AdventuresPage/components/AdventuresList/AdventuresList.tsx
+++ b/src/pages/AdventuresPage/components/AdventuresList/AdventuresList.tsx
@@ -2,7 +2,7 @@ import { FC } from 'react'
 
 import { useConnection, useWallet } from '@solana/wallet-adapter-react'
 import classNames from 'classnames'
-import { capitalize } from 'lodash'
+import { capitalize, uniqueId } from 'lodash'
 import { TxnExecutor } from 'solana-transactions-executor'
 
 import {
@@ -11,11 +11,18 @@ import {
   BanxInfoBN,
   BanxStakeBN,
 } from '@banx/api/staking'
+import { TXN_EXECUTOR_CONFIRM_OPTIONS } from '@banx/constants'
 import { checkIsSubscribed, getAdventureStatus, isAdventureEnded } from '@banx/pages/AdventuresPage'
 import { usePriorityFees } from '@banx/store'
 import { createWalletInstance, defaultTxnErrorHandler } from '@banx/transactions'
 import { subscribeBanxAdventureAction } from '@banx/transactions/staking'
-import { enqueueTransactionSent } from '@banx/utils'
+import {
+  destroySnackbar,
+  enqueueConfirmationError,
+  enqueueSnackbar,
+  enqueueTransactionsSent,
+  enqueueWaitingConfirmationSingle,
+} from '@banx/utils'
 
 import {
   AdventureEndedRewardsResult,
@@ -84,15 +91,40 @@ const AdventuresCard: FC<AdventuresCardProps> = ({
 
     const params = { weeks: [banxAdventure.week], priorityFeeLevel: priorityLevel }
 
-    new TxnExecutor(subscribeBanxAdventureAction, {
-      wallet: createWalletInstance(wallet),
-      connection,
-    })
-      .addTransactionParam(params)
-      .on('sentSome', (results) => {
-        results.forEach(({ signature }) => enqueueTransactionSent(signature))
+    const loadingSnackbarId = uniqueId()
+
+    new TxnExecutor(
+      subscribeBanxAdventureAction,
+      {
+        wallet: createWalletInstance(wallet),
+        connection,
+      },
+      {
+        confirmOptions: TXN_EXECUTOR_CONFIRM_OPTIONS,
+      },
+    )
+
+      .on('sentAll', (results) => {
+        enqueueTransactionsSent()
+        enqueueWaitingConfirmationSingle(loadingSnackbarId, results[0].signature)
+      })
+      .on('confirmedAll', (results) => {
+        destroySnackbar(loadingSnackbarId)
+
+        const { confirmed, failed } = results
+
+        if (confirmed.length) {
+          enqueueSnackbar({ message: 'Subscribed successfully', type: 'success' })
+        }
+
+        if (failed.length) {
+          return failed.forEach(({ signature, reason }) =>
+            enqueueConfirmationError(signature, reason),
+          )
+        }
       })
       .on('error', (error) => {
+        destroySnackbar(loadingSnackbarId)
         defaultTxnErrorHandler(error, {
           additionalData: params,
           walletPubkey: wallet?.publicKey?.toBase58(),

--- a/src/pages/AdventuresPage/components/Sidebar/Sidebar.tsx
+++ b/src/pages/AdventuresPage/components/Sidebar/Sidebar.tsx
@@ -5,14 +5,14 @@ import { useConnection, useWallet } from '@solana/wallet-adapter-react'
 import classNames from 'classnames'
 import { BN } from 'fbonds-core'
 import { BanxAdventureSubscriptionState } from 'fbonds-core/lib/fbond-protocol/types'
-import { chain } from 'lodash'
+import { chain, uniqueId } from 'lodash'
 import { TxnExecutor } from 'solana-transactions-executor'
 
 import { Button } from '@banx/components/Buttons'
 import { StatInfo, StatsInfoProps, VALUES_TYPES } from '@banx/components/StatInfo'
 
 import { BanxInfoBN, BanxStakingSettingsBN } from '@banx/api/staking'
-import { BANX_TOKEN_DECIMALS } from '@banx/constants'
+import { BANX_TOKEN_DECIMALS, TXN_EXECUTOR_CONFIRM_OPTIONS } from '@banx/constants'
 import { BanxToken, Gamepad, MoneyBill } from '@banx/icons'
 import {
   banxTokenBNToFixed,
@@ -28,7 +28,11 @@ import { stakeBanxClaimAction } from '@banx/transactions/staking/stakeBanxClaimA
 import {
   ZERO_BN,
   bnToFixed,
-  enqueueTransactionSent,
+  destroySnackbar,
+  enqueueConfirmationError,
+  enqueueSnackbar,
+  enqueueTransactionsSent,
+  enqueueWaitingConfirmationSingle,
   formatCompact,
   formatNumbersWithCommas,
 } from '@banx/utils'
@@ -121,12 +125,37 @@ export const Sidebar: FC<SidebarProps> = ({ className, banxStakingSettings, banx
 
     const params = { weeks, priorityFeeLevel: priorityLevel }
 
-    new TxnExecutor(stakeBanxClaimAction, { wallet: createWalletInstance(wallet), connection })
+    const loadingSnackbarId = uniqueId()
+
+    new TxnExecutor(
+      stakeBanxClaimAction,
+      { wallet: createWalletInstance(wallet), connection },
+      {
+        confirmOptions: TXN_EXECUTOR_CONFIRM_OPTIONS,
+      },
+    )
       .addTransactionParam(params)
-      .on('sentSome', (results) => {
-        results.forEach(({ signature }) => enqueueTransactionSent(signature))
+      .on('sentAll', (results) => {
+        enqueueTransactionsSent()
+        enqueueWaitingConfirmationSingle(loadingSnackbarId, results[0].signature)
+      })
+      .on('confirmedAll', (results) => {
+        destroySnackbar(loadingSnackbarId)
+
+        const { confirmed, failed } = results
+
+        if (confirmed.length) {
+          enqueueSnackbar({ message: 'Claimed successfully', type: 'success' })
+        }
+
+        if (failed.length) {
+          return failed.forEach(({ signature, reason }) =>
+            enqueueConfirmationError(signature, reason),
+          )
+        }
       })
       .on('error', (error) => {
+        destroySnackbar(loadingSnackbarId)
         defaultTxnErrorHandler(error, {
           additionalData: params,
           walletPubkey: wallet?.publicKey?.toBase58(),

--- a/src/pages/LoansPage/components/LoansActiveTable/TableCells/ActionsCell/RefinanceModal.tsx
+++ b/src/pages/LoansPage/components/LoansActiveTable/TableCells/ActionsCell/RefinanceModal.tsx
@@ -12,7 +12,7 @@ import { createPercentValueJSX, createSolValueJSX } from '@banx/components/Table
 import { Modal } from '@banx/components/modals/BaseModal'
 
 import { Loan } from '@banx/api/core'
-import { BONDS } from '@banx/constants'
+import { BONDS, TXN_EXECUTOR_CONFIRM_OPTIONS } from '@banx/constants'
 import { useMarketOffers } from '@banx/pages/LendPage'
 import { useSelectedLoans } from '@banx/pages/LoansPage/loansState'
 import { useLoansOptimistic, useModal, usePriorityFees } from '@banx/store'
@@ -23,8 +23,8 @@ import {
   calculateApr,
   calculateLoanRepayValue,
   destroySnackbar,
+  enqueueConfirmationError,
   enqueueSnackbar,
-  enqueueTranactionError,
   enqueueTransactionSent,
   enqueueWaitingConfirmation,
   filterOutWalletLoans,
@@ -129,7 +129,13 @@ export const RefinanceModal: FC<RefinanceModalProps> = ({ loan }) => {
 
     const loadingSnackbarId = uniqueId()
 
-    new TxnExecutor(makeBorrowRefinanceAction, { wallet: createWalletInstance(wallet), connection })
+    new TxnExecutor(
+      makeBorrowRefinanceAction,
+      { wallet: createWalletInstance(wallet), connection },
+      {
+        confirmOptions: TXN_EXECUTOR_CONFIRM_OPTIONS,
+      },
+    )
       .addTransactionParam({
         loan,
         offer: suitableOffer,
@@ -147,7 +153,9 @@ export const RefinanceModal: FC<RefinanceModalProps> = ({ loan }) => {
         destroySnackbar(loadingSnackbarId)
 
         if (failed.length) {
-          return enqueueTranactionError()
+          return failed.forEach(({ signature, reason }) =>
+            enqueueConfirmationError(signature, reason),
+          )
         }
 
         return confirmed.forEach(({ result, signature }) => {

--- a/src/pages/OffersPage/components/ActiveTabContent/components/LoansTable/Summary/Summary.tsx
+++ b/src/pages/OffersPage/components/ActiveTabContent/components/LoansTable/Summary/Summary.tsx
@@ -11,14 +11,15 @@ import { StatInfo, VALUES_TYPES } from '@banx/components/StatInfo'
 import { createSolValueJSX } from '@banx/components/TableComponents'
 
 import { Loan } from '@banx/api/core'
+import { TXN_EXECUTOR_CONFIRM_OPTIONS } from '@banx/constants'
 import { useIsLedger, usePriorityFees } from '@banx/store'
 import { createWalletInstance, defaultTxnErrorHandler } from '@banx/transactions'
 import { makeClaimAction, makeTerminateAction } from '@banx/transactions/loans'
 import {
   HealthColorIncreasing,
   destroySnackbar,
+  enqueueConfirmationError,
   enqueueSnackbar,
-  enqueueTranactionsError,
   enqueueTransactionsSent,
   enqueueWaitingConfirmation,
   getColorByPercent,
@@ -64,7 +65,7 @@ export const Summary: FC<SummaryProps> = ({
     new TxnExecutor(
       makeTerminateAction,
       { wallet: createWalletInstance(wallet), connection },
-      { signAllChunkSize: isLedger ? 5 : 40 },
+      { signAllChunkSize: isLedger ? 5 : 40, confirmOptions: TXN_EXECUTOR_CONFIRM_OPTIONS },
     )
       .addTransactionParams(txnParams)
       .on('sentAll', () => {
@@ -73,7 +74,6 @@ export const Summary: FC<SummaryProps> = ({
       })
       .on('confirmedAll', (results) => {
         const { confirmed, failed } = results
-        const failedTransactionsCount = failed.length
 
         destroySnackbar(loadingSnackbarId)
 
@@ -83,8 +83,10 @@ export const Summary: FC<SummaryProps> = ({
           clearSelection()
         }
 
-        if (failedTransactionsCount) {
-          return enqueueTranactionsError(failedTransactionsCount)
+        if (failed.length) {
+          return failed.forEach(({ signature, reason }) =>
+            enqueueConfirmationError(signature, reason),
+          )
         }
       })
       .on('error', (error) => {
@@ -106,7 +108,7 @@ export const Summary: FC<SummaryProps> = ({
     new TxnExecutor(
       makeClaimAction,
       { wallet: createWalletInstance(wallet), connection },
-      { signAllChunkSize: isLedger ? 5 : 40 },
+      { signAllChunkSize: isLedger ? 5 : 40, confirmOptions: TXN_EXECUTOR_CONFIRM_OPTIONS },
     )
       .addTransactionParams(txnParams)
       .on('sentAll', () => {
@@ -115,7 +117,6 @@ export const Summary: FC<SummaryProps> = ({
       })
       .on('confirmedAll', (results) => {
         const { confirmed, failed } = results
-        const failedTransactionsCount = failed.length
 
         destroySnackbar(loadingSnackbarId)
 
@@ -130,8 +131,10 @@ export const Summary: FC<SummaryProps> = ({
           hideLoans(...mintsToHidden)
         }
 
-        if (failedTransactionsCount) {
-          return enqueueTranactionsError(failedTransactionsCount)
+        if (failed.length) {
+          return failed.forEach(({ signature, reason }) =>
+            enqueueConfirmationError(signature, reason),
+          )
         }
       })
       .on('error', (error) => {

--- a/src/utils/snackbar/index.tsx
+++ b/src/utils/snackbar/index.tsx
@@ -4,6 +4,7 @@ import { notification } from 'antd'
 import { NotificationPlacement } from 'antd/es/notification/interface'
 import classNames from 'classnames'
 import { uniqueId } from 'lodash'
+import { ConfirmTransactionErrorReason } from 'solana-transactions-executor'
 
 import { CloseModal, LoaderCircle } from '@banx/icons'
 
@@ -114,3 +115,28 @@ export const enqueueTransactionsSent = () =>
     message: 'Transactions sent',
     type: 'info',
   })
+
+export const enqueueWaitingConfirmationSingle = (key: string, signature: string) => {
+  enqueueSnackbar({
+    customKey: key,
+    message: 'Waiting for confirmation',
+    type: 'loading',
+    persist: true,
+    solanaExplorerPath: `tx/${signature}`,
+  })
+}
+
+export const enqueueConfirmationError = (
+  signature: string,
+  reason: ConfirmTransactionErrorReason,
+) => {
+  if (reason === ConfirmTransactionErrorReason.TimeoutError) {
+    return enqueueSnackbar({
+      message: 'Unable to ensure transaction result. Please try again',
+      type: 'warning',
+      autoHideDuration: 7,
+      solanaExplorerPath: `tx/${signature}`,
+    })
+  }
+  return enqueueTranactionError()
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11364,10 +11364,10 @@ socks@^2.6.2:
     ip "^2.0.0"
     smart-buffer "^4.2.0"
 
-solana-transactions-executor@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/solana-transactions-executor/-/solana-transactions-executor-2.0.1.tgz#5b349bf7323e97ddc0aa9203b568dbdf482e0817"
-  integrity sha512-PcURBSZlZbvx/hjvJFp/Oxr1lnOldP+rq/GoDmVf0whlMTkwjQf+vRGwVm/N8dy1t7Ekdq3f9j+rTya85zuJzA==
+solana-transactions-executor@2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/solana-transactions-executor/-/solana-transactions-executor-2.2.4.tgz#3c1836d2823dad7ef01dccfb998cbb408333d49c"
+  integrity sha512-T/e7XunNT6C8xNzX0ToTfIP+qqgud5gVYHe2gAV17YKm/6PeW4yzZGsoWobU+702FXdkM/oHgrXNO93EEq6fEg==
   dependencies:
     "@solana/web3.js" "^1.68.0"
     lodash "^4.17.21"


### PR DESCRIPTION
* Set maxRetries = 1

* Implement enqueueWaitingConfirmationSingle snack function

* Refactor endpoints

* Change TXN_EXECUTOR_CONFIRM_OPTIONS

* Implement waiting state for stake tokens

* Update txn-executor Implement confirmationTimeout

* Set confirmationTimeout 15 sec

* Implement enqueueConfirmationError snack

* Add timeout confirmation error for all transactions Add confirmation state for staking transactions

* Destroy waiting snacks on error on StakePage

* Show TimeoutError as warning

* Change enotification text

