### PR TITLE
BAN-2618: Replace "Not enough funds" with "Not enough SOL for transaction"

### DIFF
--- a/src/transactions/types.ts
+++ b/src/transactions/types.ts
@@ -2,7 +2,7 @@ import { SnackbarType } from '@banx/utils'
 
 export enum TxnErrorHumanName {
   TRANSACTION_REJECTED = 'Transaction rejected',
-  INSUFFICIENT_LAMPORTS = 'Not enough funds',
+  INSUFFICIENT_LAMPORTS = 'Not enough SOL for transaction',
   TOKEN_IS_LOCKED = 'Token is locked',
 }
 


### PR DESCRIPTION
## Issue link

https://linear.app/banx-gg/issue/BAN-2618/not-enough-funds-error-on-borrowing-update-with-not-enough-sol-for

## Vercel preview

<!-- Feature template -->

https://banx-ui-git-feature-ban-2618-frakt.vercel.app/

