### PR TITLE
BAN-2619: Token Lending bugs and improvements

### DIFF
--- a/src/components/CommonTables/LendTokenActivityTable/LendTokenActivityTable.module.less
+++ b/src/components/CommonTables/LendTokenActivityTable/LendTokenActivityTable.module.less
@@ -75,6 +75,12 @@
 // * FilterTableSection * //
 
 // * Cells * //
+.collateralTokenCell {
+  img {
+    width: 22px;
+    height: 22px;
+  }
+}
 .cellTitle {
   font: var(--body-text-sm);
   white-space: nowrap;

--- a/src/components/CommonTables/LendTokenActivityTable/LendTokenActivityTable.module.less
+++ b/src/components/CommonTables/LendTokenActivityTable/LendTokenActivityTable.module.less
@@ -38,7 +38,7 @@
     height: 330px;
 
     &.notConnectedContent {
-      height: 256px;
+      height: 368px;
     }
   }
 }

--- a/src/components/CommonTables/LendTokenActivityTable/LendTokenActivityTable.module.less
+++ b/src/components/CommonTables/LendTokenActivityTable/LendTokenActivityTable.module.less
@@ -32,16 +32,14 @@
 }
 
 .tableWrapper {
-  height: 200px;
+  height: 228px;
 
-  &.notConnectedContent {
-    @media (max-width: 640px) {
+  @media (max-width: 640px) {
+    height: 330px;
+
+    &.notConnectedContent {
       height: 256px;
     }
-  }
-
-  &.emptyContent {
-    height: 152px;
   }
 }
 

--- a/src/components/CommonTables/LendTokenActivityTable/LendTokenActivityTable.tsx
+++ b/src/components/CommonTables/LendTokenActivityTable/LendTokenActivityTable.tsx
@@ -47,7 +47,6 @@ const LendTokenActivityTable: FC<LendTokenActivityTableProps> = ({ marketPubkey 
         loaderSize="small"
         classNameTableWrapper={classNames(styles.tableWrapper, {
           [styles.notConnectedContent]: !connected,
-          [styles.emptyContent]: connected && showEmptyList,
         })}
         emptyMessage={
           showEmptyList

--- a/src/components/CommonTables/LendTokenActivityTable/columns.tsx
+++ b/src/components/CommonTables/LendTokenActivityTable/columns.tsx
@@ -27,6 +27,7 @@ export const getTableColumns = () => {
           collateralTokenAmount={formatCollateralTokenValue(
             tokenSupply / Math.pow(10, collateral.decimals),
           )}
+          className={styles.collateralTokenCell}
         />
       ),
     },

--- a/src/components/EmptyList/EmptyList.module.less
+++ b/src/components/EmptyList/EmptyList.module.less
@@ -2,7 +2,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 24px;
+  gap: 12px;
   margin: 12px 24px;
 
   @media (max-width: 960px) {
@@ -17,7 +17,8 @@
 
 .emptyList {
   background: var(--additional-blue-secondary);
-  border: 1px solid var(--additional-blue-primary);
+  border: 0.5px solid var(--additional-blue-primary);
+  border-radius: 6px;
 
   display: flex;
   align-items: center;
@@ -37,4 +38,5 @@
 
 .emptyListButton {
   text-decoration: none;
+  width: 110px;
 }

--- a/src/components/ModeSwitcher/ModeSwitcher.module.less
+++ b/src/components/ModeSwitcher/ModeSwitcher.module.less
@@ -1,5 +1,6 @@
 .modeSwitcher {
-  background: var(--bg-tertiary);
+  background: var(--bg-primary);
+  border: var(--border-less-primary);
   border-radius: 100px;
 
   display: flex;
@@ -28,7 +29,7 @@
   }
 
   &.active {
-    background: var(--bg-primary);
+    background: var(--action-primary);
 
     span {
       color: var(--content-primary);

--- a/src/components/ModeSwitcher/ModeSwitcher.module.less
+++ b/src/components/ModeSwitcher/ModeSwitcher.module.less
@@ -4,7 +4,7 @@
 
   display: flex;
   align-items: center;
-  padding: 2px;
+  padding: 4px;
   height: 32px;
 
   user-select: none;

--- a/src/components/PlaceTokenOfferSection/PlaceTokenOfferSection.module.less
+++ b/src/components/PlaceTokenOfferSection/PlaceTokenOfferSection.module.less
@@ -1,48 +1,4 @@
-.container {
-  display: flex;
-  cursor: default;
-  height: 318px;
-  width: 100%;
-
-  @media (max-width: 960px) {
-    height: 346px;
-  }
-
-  @media (max-width: 640px) {
-    height: 330px;
-  }
-}
-
-.showOffersMobileButton {
-  max-width: 96px;
-  margin-bottom: 8px;
-
-  @media (min-width: 961px) {
-    display: none;
-  }
-}
-
-.orderBook {
-  @media (max-width: 960px) {
-    display: none !important;
-  }
-}
-
 // * Form * //
-.form {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  padding: 12px 24px 24px;
-  max-width: 432px;
-  width: 100%;
-
-  @media (max-width: 960px) {
-    padding: 8px 16px 16px;
-    max-width: unset;
-  }
-}
-
 .fieldsColumn {
   display: flex;
   flex-direction: column;

--- a/src/components/PlaceTokenOfferSection/PlaceTokenOfferSection.tsx
+++ b/src/components/PlaceTokenOfferSection/PlaceTokenOfferSection.tsx
@@ -61,7 +61,7 @@ const PlaceTokenOfferSection: FC<PlaceTokenOfferSectionProps> = ({
     <>
       <div className={styles.fieldsColumn}>
         <NumericStepInput
-          label="Max offer"
+          label="Offer"
           value={collateralsPerTokenString}
           onChange={onLoanValueChange}
           postfix={getTokenUnit(tokenType)}

--- a/src/components/PlaceTokenOfferSection/PlaceTokenOfferSection.tsx
+++ b/src/components/PlaceTokenOfferSection/PlaceTokenOfferSection.tsx
@@ -5,7 +5,6 @@ import { MAX_APR_SPL } from 'fbonds-core/lib/fbond-protocol/constants'
 import { LendingTokenType } from 'fbonds-core/lib/fbond-protocol/types'
 
 import { TokenMarketPreview } from '@banx/api/tokens'
-import { useModal } from '@banx/store/common'
 import { useNftTokenType } from '@banx/store/nft'
 import {
   convertToDecimalString,
@@ -16,9 +15,7 @@ import {
 
 import { Button } from '../Buttons'
 import { InputErrorMessage, NumericStepInput } from '../inputs'
-import { Modal } from '../modals/BaseModal'
 import { ActionsButtons } from './components/ActionsButtons'
-import OrderBook from './components/OrderBook'
 import { AdditionalSummary } from './components/Summary'
 import { formatLeadingZeros, getCollateralDecimalPlaces } from './helpers'
 import { usePlaceTokenOffer } from './hooks/usePlaceTokenOffer'
@@ -53,115 +50,79 @@ const PlaceTokenOfferSection: FC<PlaceTokenOfferSectionProps> = ({
   } = usePlaceTokenOffer(marketPubkey, offerPubkey)
 
   const { connected } = useWallet()
-  const { open } = useModal()
 
   const { tokenType } = useNftTokenType()
-
-  const showModal = () => {
-    open(OffersModal, { market, offerPubkey })
-  }
 
   const marketTokenDecimals = getTokenDecimals(tokenType) //? 1e6, 1e9
 
   const inputStepByTokenType = isBanxSolTokenType(tokenType) ? 0.1 : 1
 
   return (
-    <div className={styles.container}>
-      <div className={styles.form}>
-        <Button
-          className={styles.showOffersMobileButton}
-          onClick={showModal}
-          type="circle"
-          variant="tertiary"
-        >
-          See offers
-        </Button>
-
-        <div className={styles.fieldsColumn}>
-          <NumericStepInput
-            label="Max offer"
-            value={collateralsPerTokenString}
-            onChange={onLoanValueChange}
-            postfix={getTokenUnit(tokenType)}
-            disabled={!connected}
-            step={inputStepByTokenType}
-            rightLabelJSX={
-              <MaxOfferControls
-                market={market}
-                onChange={onLoanValueChange}
-                tokenType={tokenType}
-              />
-            }
-          />
-          <div className={styles.fieldsRow}>
-            <div className={styles.fieldColumn}>
-              <NumericStepInput
-                label="Offer size"
-                value={offerSizeString}
-                onChange={onOfferSizeChange}
-                postfix={getTokenUnit(tokenType)}
-                disabled={!connected}
-                step={inputStepByTokenType}
-              />
-              <div className={styles.messageContainer}>
-                {offerErrorMessage && <InputErrorMessage message={offerErrorMessage} />}
-              </div>
+    <>
+      <div className={styles.fieldsColumn}>
+        <NumericStepInput
+          label="Max offer"
+          value={collateralsPerTokenString}
+          onChange={onLoanValueChange}
+          postfix={getTokenUnit(tokenType)}
+          disabled={!connected}
+          step={inputStepByTokenType}
+          rightLabelJSX={
+            <MaxOfferControls market={market} onChange={onLoanValueChange} tokenType={tokenType} />
+          }
+        />
+        <div className={styles.fieldsRow}>
+          <div className={styles.fieldColumn}>
+            <NumericStepInput
+              label="Offer size"
+              value={offerSizeString}
+              onChange={onOfferSizeChange}
+              postfix={getTokenUnit(tokenType)}
+              disabled={!connected}
+              step={inputStepByTokenType}
+            />
+            <div className={styles.messageContainer}>
+              {offerErrorMessage && <InputErrorMessage message={offerErrorMessage} />}
             </div>
+          </div>
 
-            <div className={styles.fieldColumn}>
-              <NumericStepInput
-                label="Apr"
-                value={aprString}
-                onChange={onAprChange}
-                postfix="%"
-                disabled={!connected}
-                step={1}
-                max={MAX_APR_SPL / 100}
-              />
-              <div className={styles.messageContainer}>
-                {aprErrorMessage && <InputErrorMessage message={aprErrorMessage} />}
-              </div>
+          <div className={styles.fieldColumn}>
+            <NumericStepInput
+              label="Apr"
+              value={aprString}
+              onChange={onAprChange}
+              postfix="%"
+              disabled={!connected}
+              step={1}
+              max={MAX_APR_SPL / 100}
+            />
+            <div className={styles.messageContainer}>
+              {aprErrorMessage && <InputErrorMessage message={aprErrorMessage} />}
             </div>
           </div>
         </div>
-
-        <AdditionalSummary
-          market={market}
-          collateralPerToken={collateralsPerTokenString}
-          offerSize={parseFloat(offerSizeString) * marketTokenDecimals}
-          apr={parseFloat(aprString)}
-        />
-
-        <ActionsButtons
-          onCreateOffer={onCreateTokenOffer}
-          onRemoveOffer={onRemoveTokenOffer}
-          onUpdateOffer={onUpdateTokenOffer}
-          disablePlaceOffer={disablePlaceOffer}
-          disableUpdateOffer={disableUpdateOffer}
-          isEditMode={isEditMode}
-        />
       </div>
-      <OrderBook market={market} offerPubkey={offerPubkey} className={styles.orderBook} />
-    </div>
+
+      <AdditionalSummary
+        market={market}
+        collateralPerToken={collateralsPerTokenString}
+        offerSize={parseFloat(offerSizeString) * marketTokenDecimals}
+        apr={parseFloat(aprString)}
+      />
+
+      <ActionsButtons
+        onCreateOffer={onCreateTokenOffer}
+        onRemoveOffer={onRemoveTokenOffer}
+        onUpdateOffer={onUpdateTokenOffer}
+        disablePlaceOffer={disablePlaceOffer}
+        disableUpdateOffer={disableUpdateOffer}
+        isEditMode={isEditMode}
+      />
+    </>
   )
 }
 
 export default PlaceTokenOfferSection
-
-interface OffersModalProps {
-  market: TokenMarketPreview | undefined
-  offerPubkey: string
-}
-
-export const OffersModal: FC<OffersModalProps> = (props) => {
-  const { close } = useModal()
-
-  return (
-    <Modal className={styles.modal} open onCancel={close}>
-      <OrderBook {...props} />
-    </Modal>
-  )
-}
 
 interface MaxOfferControlsProps {
   market: TokenMarketPreview | undefined

--- a/src/components/PlaceTokenOfferSection/components/OrderBook/OrderBook.module.less
+++ b/src/components/PlaceTokenOfferSection/components/OrderBook/OrderBook.module.less
@@ -1,6 +1,8 @@
 .orderBook {
   display: flex;
   flex-direction: column;
+
+  height: 100%;
   width: 100%;
 
   @media (max-width: 960px) {
@@ -50,7 +52,6 @@
   background: var(--bg-primary);
   margin-top: 6px;
   overflow-y: auto;
-  height: 100%;
 }
 
 // * Offer * //

--- a/src/components/PlaceTokenOfferSection/components/OrderBook/OrderBook.module.less
+++ b/src/components/PlaceTokenOfferSection/components/OrderBook/OrderBook.module.less
@@ -63,7 +63,7 @@
   min-height: 38px;
   width: 100%;
 
-  &:nth-child(even) {
+  &:nth-child(odd) {
     background: var(--bg-secondary);
   }
 

--- a/src/components/PlaceTokenOfferSection/hooks/useOfferFormController.ts
+++ b/src/components/PlaceTokenOfferSection/hooks/useOfferFormController.ts
@@ -12,6 +12,8 @@ import {
   getTokenDecimals,
 } from '@banx/utils'
 
+const DEFAULT_APR_PERCENT = 30
+
 export const useOfferFormController = (
   syntheticOffer: SyntheticTokenOffer,
   market: TokenMarketPreview | undefined,
@@ -39,7 +41,7 @@ export const useOfferFormController = (
     return {
       collateralsPerToken: formatTokensPerCollateralToStr(collateralsPerToken),
       offerSize: offerSize ? String(offerSize) : '0',
-      apr: syntheticApr ? String(syntheticApr) : '0',
+      apr: syntheticApr ? String(syntheticApr) : DEFAULT_APR_PERCENT.toString(),
     }
   }, [decimals, market, syntheticApr, syntheticCollateralsPerToken, syntheticOfferSize])
 

--- a/src/components/PlaceTokenOfferSection/index.ts
+++ b/src/components/PlaceTokenOfferSection/index.ts
@@ -1,1 +1,4 @@
 export { default } from './PlaceTokenOfferSection'
+export { default as OrderBook } from './components/OrderBook'
+
+export * from './helpers'

--- a/src/components/SearchSelect/SearchSelect.module.less
+++ b/src/components/SearchSelect/SearchSelect.module.less
@@ -51,8 +51,8 @@
   padding-left: 12px;
 
   svg {
-    width: 20px;
-    height: 20px;
+    width: 16px;
+    height: 16px;
   }
 
   svg path {

--- a/src/components/SearchSelect/SelectOption/SelectOption.module.less
+++ b/src/components/SearchSelect/SelectOption/SelectOption.module.less
@@ -11,8 +11,8 @@
 }
 
 .addToFavoriteIcon {
-  height: 24px;
-  width: 24px;
+  height: 16px;
+  width: 16px;
 }
 
 .optionLabel {
@@ -33,13 +33,8 @@
   &,
   img,
   .selected {
-    height: 32px;
-    width: 32px;
-
-    @media (max-width: 640px) {
-      height: 24px;
-      width: 24px;
-    }
+    height: 24px;
+    width: 24px;
   }
 }
 

--- a/src/components/Table/Table.module.less
+++ b/src/components/Table/Table.module.less
@@ -1,7 +1,8 @@
 .emptyList {
   background: var(--additional-blue-secondary);
-  border: 1px solid var(--additional-blue-primary);
-  font: var(--body-text-md);
+  border: 0.5px solid var(--additional-blue-primary);
+  border-radius: 6px;
+
   padding: 6px 16px;
   margin: 8px 24px;
 

--- a/src/components/TableComponents/CollaterallCell.tsx
+++ b/src/components/TableComponents/CollaterallCell.tsx
@@ -129,6 +129,7 @@ interface CollateralTokenCellProps {
   onCheckboxClick?: () => void
   checkboxClassName?: string
 
+  className?: string
   rightContentJSX?: ReactNode
 }
 
@@ -140,6 +141,7 @@ export const CollateralTokenCell: FC<CollateralTokenCellProps> = ({
   checkboxClassName,
   selected = false,
   rightContentJSX,
+  className,
 }) => {
   const { viewState } = useTableView()
   const isCardView = viewState === ViewState.CARD
@@ -154,7 +156,7 @@ export const CollateralTokenCell: FC<CollateralTokenCellProps> = ({
         />
       )}
 
-      <div className={styles.collateralTokenContainer}>
+      <div className={classNames(styles.collateralTokenContainer, className)}>
         <img src={collateralImageUrl} className={styles.collateralImage} />
         <div className={styles.collateralTokenInfo}>
           <span className={styles.collateralTokenAmount}>{collateralTokenAmount}</span>

--- a/src/components/Tabs/Tabs.module.less
+++ b/src/components/Tabs/Tabs.module.less
@@ -42,9 +42,25 @@
   border-left: var(--border-less-primary);
 }
 
+//? The right border will not be displayed if there are only two elements.
+.primary:first-child:nth-last-child(2) {
+  border-right: none;
+}
+
 .tabActive {
-  border-bottom-color: transparent;
-  background: transparent;
+  border-bottom-color: var(--bg-primary);
+  background: var(--bg-primary-gradient);
+  position: relative;
+
+  &::after {
+    content: '';
+    background-color: var(--accent-primary);
+    display: block;
+    position: absolute;
+    top: -1px;
+    height: 1px;
+    width: 100%;
+  }
 
   &,
   &:hover {

--- a/src/components/TokenSwitcher/TokenSwitcher.module.less
+++ b/src/components/TokenSwitcher/TokenSwitcher.module.less
@@ -1,6 +1,7 @@
 // * TokenSwitcher * //
 .switcher {
-  background: var(--bg-tertiary);
+  background: var(--bg-primary);
+  border: var(--border-less-primary);
   border-radius: 100px;
   cursor: pointer;
 
@@ -26,7 +27,7 @@
   width: 100%;
 
   &.active {
-    background: var(--bg-primary);
+    background: var(--action-primary);
     color: var(--content-primary);
   }
 }

--- a/src/components/TokenSwitcher/TokenSwitcher.module.less
+++ b/src/components/TokenSwitcher/TokenSwitcher.module.less
@@ -6,7 +6,7 @@
 
   display: flex;
   align-items: center;
-  padding: 2px;
+  padding: 4px;
   height: 32px;
 
   user-select: none;

--- a/src/less/abstracts/variables.less
+++ b/src/less/abstracts/variables.less
@@ -14,6 +14,8 @@
   --bg-border: #cccccc;
   --bg-border-active: #888888;
 
+  --bg-primary-gradient: linear-gradient(180deg, #e0f9c0 0%, #fefeff 75%);
+
   --content-primary: #1b1b1b;
   --content-secondary: #616161;
   --content-tertiary: #8c8c8c;
@@ -104,6 +106,8 @@
   --bg-tertiary: #040404;
   --bg-border: #38383c;
   --bg-border-active: #8c8c8c;
+
+  --bg-primary-gradient: linear-gradient(180deg, #14230e 0%, #151516 67%);
 
   --content-primary: #d3d3d3;
   --content-secondary: #8d8d8d;

--- a/src/pages/nftLending/LendPage/PlaceOffersContent/components/Offer/Offer.module.less
+++ b/src/pages/nftLending/LendPage/PlaceOffersContent/components/Offer/Offer.module.less
@@ -7,7 +7,7 @@
   min-height: 32px;
   width: 100%;
 
-  &:nth-child(even) {
+  &:nth-child(odd) {
     background: var(--bg-secondary);
   }
 

--- a/src/pages/nftLending/OffersPage/components/ActiveTabContent/components/LoansTable/columns.tsx
+++ b/src/pages/nftLending/OffersPage/components/ActiveTabContent/components/LoansTable/columns.tsx
@@ -110,7 +110,7 @@ export const getTableColumns = ({
       title: (
         <HeaderCell
           label="Repaid"
-          tooltipText="Repayments returned to pending offer if open, or wallet if closed"
+          tooltipText="Repayments returned to the vault and can be claimed from the pending tab or profile modal"
         />
       ),
       render: ({ totalRepaidAmount = 0 }) => (

--- a/src/pages/tokenLending/BorrowTokenPage/BorrowTokenPage.module.less
+++ b/src/pages/tokenLending/BorrowTokenPage/BorrowTokenPage.module.less
@@ -1,12 +1,8 @@
-.content {
+.pageWrapper {
   display: flex;
-  justify-content: center;
-  padding: 24px;
-
-  @media (max-width: 640px) {
-    padding: 0;
-    padding-bottom: 96px;
-  }
+  flex-direction: column;
+  max-height: 100%;
+  height: 100%;
 }
 
 // * LtvSlider * //
@@ -26,6 +22,12 @@
       var(--additional-orange-primary),
       var(--additional-red-primary)
     ) !important;
+  }
+
+  .sliderDisabled {
+    .ant-slider-handle {
+      border-color: var(--content-secondary) !important;
+    }
   }
 
   .ant-slider-track {

--- a/src/pages/tokenLending/BorrowTokenPage/BorrowTokenPage.tsx
+++ b/src/pages/tokenLending/BorrowTokenPage/BorrowTokenPage.tsx
@@ -30,14 +30,12 @@ export const BorrowTokenPage = () => {
   }, [setTab, storeTab])
 
   return (
-    <>
+    <div className={styles.pageWrapper}>
       <BorrowHeader />
       <Tabs value={currentTabValue} tabs={tabs} setValue={setValue} />
-      <div className={styles.content}>
-        {currentTabValue === BorrowTokenTabName.INSTANT && <InstantBorrowContent />}
-        {currentTabValue === BorrowTokenTabName.LIST && <ListLoansContent />}
-      </div>
-    </>
+      {currentTabValue === BorrowTokenTabName.INSTANT && <InstantBorrowContent />}
+      {currentTabValue === BorrowTokenTabName.LIST && <ListLoansContent />}
+    </div>
   )
 }
 

--- a/src/pages/tokenLending/BorrowTokenPage/InstantBorrowContent/InstantBorrowContent.module.less
+++ b/src/pages/tokenLending/BorrowTokenPage/InstantBorrowContent/InstantBorrowContent.module.less
@@ -107,12 +107,6 @@
   }
 }
 
-.collateralLogo {
-  border-radius: 100%;
-  width: 16px;
-  height: 16px;
-}
-
 .warningModalFooter {
   display: flex;
   align-items: center;

--- a/src/pages/tokenLending/BorrowTokenPage/InstantBorrowContent/InstantBorrowContent.module.less
+++ b/src/pages/tokenLending/BorrowTokenPage/InstantBorrowContent/InstantBorrowContent.module.less
@@ -2,7 +2,18 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: 24px;
   width: 100%;
+
+  @media (max-width: 960px) {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    justify-content: space-between;
+    padding: 0;
+
+    overflow: hidden;
+  }
 }
 
 .content {
@@ -16,10 +27,37 @@
   max-width: 392px;
   width: 100%;
 
-  @media (max-width: 640px) {
+  @media (max-width: 960px) {
     border: 0;
-    padding: 16px;
+    padding: 16px 16px 0;
+  }
+
+  @media (max-width: 640px) {
     max-width: unset;
+  }
+}
+
+.footerContent {
+  border-top: 1px dotted var(--bg-border);
+
+  display: flex;
+  flex-direction: column;
+  padding: 12px 24px 0;
+  margin: 0 -24px 0;
+  gap: 16px;
+
+  @media (max-width: 960px) {
+    background: var(--bg-primary);
+
+    padding: 8px 16px 16px;
+    margin: 0;
+    gap: 8px;
+
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 1;
   }
 }
 
@@ -29,17 +67,11 @@
 
 // * Summary * //
 .summary {
-  border-top: 1px dotted var(--bg-border);
-
   display: flex;
   flex-direction: column;
-  padding: 12px 24px 0;
-  margin: 0 -24px 0;
   gap: 8px;
 
-  @media (max-width: 640px) {
-    padding: 8px 16px 8px;
-    margin: 0 -16px 0;
+  @media (max-width: 960px) {
     gap: 4px;
   }
 }
@@ -47,7 +79,6 @@
 .fixedStatValue {
   max-width: 74px;
   white-space: nowrap;
-  overflow: auto;
 
   @media (max-width: 960px) {
     max-width: 144px;
@@ -56,7 +87,6 @@
 // * Summary * //
 
 .borrowButton {
-  margin-top: 16px;
   width: 100%;
 }
 
@@ -130,3 +160,37 @@
   width: 100%;
 }
 // * WarningModal * //
+
+.orderBookContainer {
+  border: var(--border-primary);
+  border-left: 0;
+  border-radius: 12px;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+
+  padding-top: 12px;
+
+  height: 100%;
+  width: 100%;
+
+  @media (max-width: 960px) {
+    border: 0;
+
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    justify-content: space-between;
+    padding: 0 0 140px;
+
+    overflow: hidden;
+    height: unset;
+  }
+}
+
+.loader {
+  height: 100%;
+
+  path {
+    fill: #9cff1f;
+  }
+}

--- a/src/pages/tokenLending/BorrowTokenPage/InstantBorrowContent/InstantBorrowContent.tsx
+++ b/src/pages/tokenLending/BorrowTokenPage/InstantBorrowContent/InstantBorrowContent.tsx
@@ -1,12 +1,14 @@
 import { useWallet } from '@solana/wallet-adapter-react'
 
 import { Button } from '@banx/components/Buttons'
+import { Loader } from '@banx/components/Loader'
 import { useWalletModal } from '@banx/components/WalletModal'
 
 import { useModal } from '@banx/store/common'
 
 import { LoanValueSlider } from '../components'
 import InputTokenSelect from '../components/InputTokenSelect'
+import MarketOrderBook from './MarketOrderBook'
 import OrderBook from './OrderBook'
 import { Summary } from './Summary'
 import WarningModal from './WarningModal'
@@ -65,6 +67,8 @@ const InstantBorrowContent = () => {
     })
   }
 
+  const loading = isLoading && !!parseFloat(collateralInputValue)
+
   return (
     <div className={styles.container}>
       <div className={styles.content}>
@@ -91,26 +95,42 @@ const InstantBorrowContent = () => {
           disabled
         />
 
-        <LoanValueSlider label="Max LTV" value={ltvSliderValue} onChange={onChangeLtvSlider} />
+        <LoanValueSlider
+          label="Max LTV"
+          value={ltvSliderValue}
+          onChange={onChangeLtvSlider}
+          disabled={!parseFloat(collateralInputValue)}
+        />
 
-        <Summary offers={offersInCart} />
+        <div className={styles.footerContent}>
+          <Summary offers={offersInCart} />
 
-        <Button
-          onClick={onSubmit}
-          className={styles.borrowButton}
-          disabled={wallet.connected && (!!errorMessage || !offersInCart.length)}
-          loading={!errorMessage && (isBorrowing || isLoading)}
-        >
-          {getButtonActionText({ isWalletConnected: wallet.connected, errorMessage })}
-        </Button>
+          <Button
+            onClick={onSubmit}
+            className={styles.borrowButton}
+            disabled={wallet.connected && (!!errorMessage || !offersInCart.length)}
+            loading={!errorMessage && (isBorrowing || loading)}
+          >
+            {getButtonActionText({ isWalletConnected: wallet.connected, errorMessage })}
+          </Button>
+        </div>
       </div>
-      <OrderBook
-        offers={offers}
-        isLoading={isLoading}
-        requiredCollateralsAmount={collateralInputValue}
-        collateral={collateralToken}
-        errorMessage={errorMessage}
-      />
+
+      <div className={styles.orderBookContainer}>
+        {loading && <Loader className={styles.loader} />}
+
+        {!loading && !offers.length && !!collateralToken && (
+          <MarketOrderBook collateral={collateralToken} />
+        )}
+
+        {!loading && !!offers.length && (
+          <OrderBook
+            offers={offers}
+            requiredCollateralsAmount={collateralInputValue}
+            collateral={collateralToken}
+          />
+        )}
+      </div>
     </div>
   )
 }

--- a/src/pages/tokenLending/BorrowTokenPage/InstantBorrowContent/MarketOrderBook/MarketOrderBook.module.less
+++ b/src/pages/tokenLending/BorrowTokenPage/InstantBorrowContent/MarketOrderBook/MarketOrderBook.module.less
@@ -11,11 +11,32 @@
 }
 
 .tableWrapper {
+  position: relative;
   height: 100%;
+
+  &.showOverlay::after {
+    content: '';
+    display: block;
+
+    background-color: var(--bg-secondary);
+    opacity: 0.5;
+
+    pointer-events: none;
+    position: absolute;
+    top: 0;
+    z-index: 2;
+
+    width: 100%;
+    height: 100%;
+  }
 
   @media (max-width: 960px) {
     height: 100vh;
   }
+}
+
+.tableLoader {
+  height: 100%;
 }
 
 // * Cells * //
@@ -26,8 +47,9 @@
 }
 
 .checkbox {
-  height: 16px;
   padding-left: 18px;
+  pointer-events: none;
+  height: 16px;
 }
 
 .aprRow {
@@ -38,18 +60,22 @@
 
 .aprValue {
   text-align: center;
+
+  @media (max-width: 640px) {
+    font: var(--body-text-sm);
+  }
 }
 
-.aprValue,
 .offerSizeValue {
   @media (max-width: 640px) {
     font: var(--body-text-sm);
   }
 }
 
-.borrowValueContainer {
+.borrowCell {
   color: var(--content-secondary);
   font: var(--important-text-lg);
+
   display: flex;
   flex-direction: column;
 

--- a/src/pages/tokenLending/BorrowTokenPage/InstantBorrowContent/MarketOrderBook/MarketOrderBook.tsx
+++ b/src/pages/tokenLending/BorrowTokenPage/InstantBorrowContent/MarketOrderBook/MarketOrderBook.tsx
@@ -1,0 +1,76 @@
+import { FC, useMemo } from 'react'
+
+import { useWallet } from '@solana/wallet-adapter-react'
+import classNames from 'classnames'
+import { chain } from 'lodash'
+
+import { calculateLtvPercent } from '@banx/components/PlaceTokenOfferSection'
+import Table from '@banx/components/Table'
+
+import { CollateralToken } from '@banx/api/tokens'
+import { useTokenMarketOffers } from '@banx/pages/tokenLending/LendTokenPage'
+import { useNftTokenType } from '@banx/store/nft'
+import {
+  calculateTokensPerCollateral,
+  formatTokensPerCollateralToStr,
+  getTokenDecimals,
+} from '@banx/utils'
+
+import { getTableColumns } from './columns'
+
+import styles from './MarketOrderBook.module.less'
+
+interface MarketOrderBookProps {
+  collateral: CollateralToken
+}
+
+const MAX_LTV_THRESHOLD = 100
+
+const MarketOrderBook: FC<MarketOrderBookProps> = ({ collateral }) => {
+  const { publicKey } = useWallet()
+  const { offers, isLoading } = useTokenMarketOffers(collateral.marketPubkey)
+
+  const { tokenType } = useNftTokenType()
+  const columns = getTableColumns({ collateral, tokenType })
+
+  const marketTokenDecimals = Math.log10(getTokenDecimals(tokenType)) //? 1e9 => 9, 1e6 => 6
+
+  const filteredOffers = useMemo(() => {
+    return chain(offers)
+      .filter((offer) => offer.assetReceiver.toBase58() !== publicKey?.toBase58())
+      .filter((offer) => {
+        const tokensPerCollateral = formatTokensPerCollateralToStr(
+          calculateTokensPerCollateral(
+            offer.validation.collateralsPerToken,
+            collateral.collateral.decimals,
+          ),
+        )
+
+        const ltvPercent = calculateLtvPercent({
+          collateralPerToken: tokensPerCollateral,
+          collateralPrice: collateral.collateralPrice,
+          marketTokenDecimals,
+        })
+
+        return ltvPercent <= MAX_LTV_THRESHOLD
+      })
+      .sortBy((offer) => offer.validation.collateralsPerToken.toNumber())
+      .value()
+  }, [collateral, marketTokenDecimals, offers, publicKey])
+
+  return (
+    <Table
+      data={filteredOffers}
+      columns={columns}
+      className={styles.table}
+      classNameTableWrapper={classNames(styles.tableWrapper, {
+        [styles.showOverlay]: !!offers.length,
+      })}
+      emptyMessage={!filteredOffers.length ? 'Not found suitable offers' : ''}
+      loaderClassName={styles.tableLoader}
+      loading={isLoading}
+    />
+  )
+}
+
+export default MarketOrderBook

--- a/src/pages/tokenLending/BorrowTokenPage/InstantBorrowContent/MarketOrderBook/columns.tsx
+++ b/src/pages/tokenLending/BorrowTokenPage/InstantBorrowContent/MarketOrderBook/columns.tsx
@@ -1,0 +1,113 @@
+import { FC } from 'react'
+
+import { BondOfferV3, LendingTokenType } from 'fbonds-core/lib/fbond-protocol/types'
+
+import Checkbox from '@banx/components/Checkbox'
+import { calculateLtvPercent } from '@banx/components/PlaceTokenOfferSection'
+import { ColumnType } from '@banx/components/Table'
+import { DisplayValue, HeaderCell, createPercentValueJSX } from '@banx/components/TableComponents'
+
+import { convertBondOfferV3ToCore } from '@banx/api/nft'
+import { CollateralToken } from '@banx/api/tokens'
+import {
+  adjustAmountWithUpfrontFee,
+  calculateIdleFundsInOffer,
+  calculateTokensPerCollateral,
+  formatTokensPerCollateralToStr,
+  getTokenDecimals,
+} from '@banx/utils'
+
+import styles from './MarketOrderBook.module.less'
+
+type GetTableColumns = (props: {
+  collateral: CollateralToken
+  tokenType: LendingTokenType
+}) => ColumnType<BondOfferV3>[]
+
+export const getTableColumns: GetTableColumns = ({ collateral, tokenType }) => {
+  const columns: ColumnType<BondOfferV3>[] = [
+    {
+      key: 'borrow',
+      title: (
+        <div className={styles.checkboxRow}>
+          <Checkbox className={styles.checkbox} onChange={() => null} checked={false} />
+          <HeaderCell label="To borrow" />
+        </div>
+      ),
+      render: (offer) => {
+        return (
+          <div className={styles.checkboxRow}>
+            <Checkbox className={styles.checkbox} onChange={() => null} checked={false} />
+            <BorrowCell offer={offer} collateral={collateral} tokenType={tokenType} />
+          </div>
+        )
+      },
+    },
+    {
+      key: 'apr',
+      title: (
+        <div className={styles.aprRow}>
+          <HeaderCell label="APR" />
+        </div>
+      ),
+      render: (offer) => <AprCell offer={offer} />,
+    },
+    {
+      key: 'offerSize',
+      title: <HeaderCell label="Offer size" />,
+      render: (offer) => (
+        <span className={styles.offerSizeValue}>
+          <DisplayValue
+            value={calculateIdleFundsInOffer(convertBondOfferV3ToCore(offer)).toNumber()}
+          />
+        </span>
+      ),
+    },
+  ]
+
+  return columns
+}
+
+const AprCell: FC<{ offer: BondOfferV3 }> = ({ offer }) => {
+  const aprRateWithProtocolFee = offer.loanApr.toNumber()
+  const aprPercent = aprRateWithProtocolFee / 100
+
+  return (
+    <div className={styles.aprRow}>
+      <span className={styles.aprValue}>{createPercentValueJSX(aprPercent)}</span>
+    </div>
+  )
+}
+
+interface BorrowCellProps {
+  offer: BondOfferV3
+  collateral: CollateralToken
+  tokenType: LendingTokenType
+}
+
+export const BorrowCell: FC<BorrowCellProps> = ({ offer, collateral, tokenType }) => {
+  const marketTokenDecimals = Math.log10(getTokenDecimals(tokenType)) //? 1e9 => 9, 1e6 => 6
+
+  const offerSize = calculateIdleFundsInOffer(convertBondOfferV3ToCore(offer))
+  const adjustedBorrowValueToDisplay = adjustAmountWithUpfrontFee(offerSize)
+
+  const tokensPerCollateral = formatTokensPerCollateralToStr(
+    calculateTokensPerCollateral(
+      offer.validation.collateralsPerToken,
+      collateral.collateral.decimals,
+    ),
+  )
+
+  const ltvPercent = calculateLtvPercent({
+    collateralPerToken: tokensPerCollateral,
+    collateralPrice: collateral.collateralPrice,
+    marketTokenDecimals,
+  })
+
+  return (
+    <div className={styles.borrowCell}>
+      <DisplayValue value={adjustedBorrowValueToDisplay.toNumber()} />
+      <span className={styles.ltvValue}>{createPercentValueJSX(ltvPercent)} LTV</span>
+    </div>
+  )
+}

--- a/src/pages/tokenLending/BorrowTokenPage/InstantBorrowContent/MarketOrderBook/index.ts
+++ b/src/pages/tokenLending/BorrowTokenPage/InstantBorrowContent/MarketOrderBook/index.ts
@@ -1,0 +1,1 @@
+export { default } from './MarketOrderBook'

--- a/src/pages/tokenLending/BorrowTokenPage/InstantBorrowContent/OrderBook/OrderBook.tsx
+++ b/src/pages/tokenLending/BorrowTokenPage/InstantBorrowContent/OrderBook/OrderBook.tsx
@@ -17,19 +17,11 @@ import styles from './OrderBook.module.less'
 
 interface OrderBookProps {
   offers: BorrowOffer[]
-  isLoading: boolean
   requiredCollateralsAmount: string //? input value string
   collateral: CollateralToken | undefined
-  errorMessage: string | undefined
 }
 
-const OrderBook: FC<OrderBookProps> = ({
-  offers,
-  isLoading,
-  requiredCollateralsAmount,
-  collateral,
-  errorMessage,
-}) => {
+const OrderBook: FC<OrderBookProps> = ({ offers, requiredCollateralsAmount, collateral }) => {
   const { tokenType } = useNftTokenType()
 
   const marketTokenDecimals = Math.log10(getTokenDecimals(tokenType)) //? 1e9 => 9, 1e6 => 6
@@ -127,21 +119,14 @@ const OrderBook: FC<OrderBookProps> = ({
     }
   }, [offerWithHighestOfferSize, onRowClick])
 
-  const loading = isLoading && !stringToBN(requiredCollateralsAmount, marketTokenDecimals).isZero()
-
   return (
-    <div className={styles.container}>
-      <Table
-        data={offers}
-        columns={columns}
-        rowParams={rowParams}
-        className={styles.table}
-        classNameTableWrapper={styles.tableWrapper}
-        emptyMessage={!offers.length ? errorMessage : ''}
-        loaderClassName={styles.tableLoader}
-        loading={loading}
-      />
-    </div>
+    <Table
+      data={offers}
+      columns={columns}
+      rowParams={rowParams}
+      className={styles.table}
+      classNameTableWrapper={styles.tableWrapper}
+    />
   )
 }
 

--- a/src/pages/tokenLending/BorrowTokenPage/InstantBorrowContent/OrderBook/columns.tsx
+++ b/src/pages/tokenLending/BorrowTokenPage/InstantBorrowContent/OrderBook/columns.tsx
@@ -74,7 +74,11 @@ export const getTableColumns: GetTableColumns = ({
     {
       key: 'offerSize',
       title: <HeaderCell label="Offer size" />,
-      render: (offer) => <DisplayValue value={parseFloat(offer.maxTokenToGet)} />,
+      render: (offer) => (
+        <span className={styles.offerSizeValue}>
+          <DisplayValue value={parseFloat(offer.maxTokenToGet)} />
+        </span>
+      ),
     },
   ]
 

--- a/src/pages/tokenLending/BorrowTokenPage/InstantBorrowContent/WarningModal.tsx
+++ b/src/pages/tokenLending/BorrowTokenPage/InstantBorrowContent/WarningModal.tsx
@@ -49,12 +49,11 @@ const WarningModal: FC<WarningModalProps> = ({ offers, onSubmit, onCancel, colla
         <div className={styles.warningModalText}>
           Lenders can only provide{' '}
           <span className={styles.warningModalTokenValue}>
-            {formattedTotalAmountToGet} {tokenUnit}
+            {createDisplayValueJSX(formattedTotalAmountToGet, tokenUnit)}
           </span>{' '}
           collateralized by{' '}
           <span className={styles.warningModalTokenRow}>
-            {formattedCollateralsValue}{' '}
-            <img className={styles.collateralLogo} src={collateral?.collateral.logoUrl} />
+            {formattedCollateralsValue} {collateral?.collateral.ticker}
           </span>{' '}
           with {formattedAprValue}% APR (est weekly fee is{' '}
           <span className={styles.warningModalTokenValue}>

--- a/src/pages/tokenLending/BorrowTokenPage/InstantBorrowContent/helpers.ts
+++ b/src/pages/tokenLending/BorrowTokenPage/InstantBorrowContent/helpers.ts
@@ -31,7 +31,7 @@ export const getErrorMessage = ({
   const ticker = collateralToken?.collateral.ticker || ''
 
   const collateralTokenBalance = bnToHuman(
-    new BN(collateralToken?.amountInWallet || 0),
+    new BN(String(collateralToken?.amountInWallet || 0)),
     collateralToken?.collateral.decimals,
   ).toString()
 

--- a/src/pages/tokenLending/BorrowTokenPage/InstantBorrowContent/hooks/useCollateralsList.ts
+++ b/src/pages/tokenLending/BorrowTokenPage/InstantBorrowContent/hooks/useCollateralsList.ts
@@ -33,10 +33,15 @@ export const useCollateralsList = () => {
 
     return [...data]
       .filter((token) => token.collateral.mint !== collateralMintToRemove)
-      .sort((a, b) => b.amountInWallet - a.amountInWallet)
+      .sort((a, b) => calculateCollateralValueInUsd(b) - calculateCollateralValueInUsd(a))
   }, [data, tokenType])
 
   return { collateralsList: sortedCollateralsList, isLoading }
+}
+
+const calculateCollateralValueInUsd = (token: core.CollateralToken) => {
+  const { collateral, amountInWallet, collateralPrice } = token
+  return (amountInWallet / Math.pow(10, collateral.decimals)) * collateralPrice
 }
 
 export const useBorrowTokensList = () => {

--- a/src/pages/tokenLending/LendTokenPage/PlaceTokenOffers/components/ExpandedCardContent/ExpandedCardContent.module.less
+++ b/src/pages/tokenLending/LendTokenPage/PlaceTokenOffers/components/ExpandedCardContent/ExpandedCardContent.module.less
@@ -1,0 +1,62 @@
+.container {
+  cursor: default;
+  display: flex;
+  overflow: hidden;
+  height: 318px;
+  width: 100%;
+
+  @media (max-width: 960px) {
+    height: 346px;
+  }
+
+  @media (max-width: 640px) {
+    height: 330px;
+  }
+}
+
+.tabsContent {
+  border: var(--border-less-primary);
+  border-right: 0;
+  border-bottom: 0;
+  width: 100%;
+
+  @media (max-width: 960px) {
+    display: none;
+  }
+}
+
+.placeOfferContainer {
+  cursor: default;
+
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 12px 24px 24px;
+
+  max-width: 432px;
+  width: 100%;
+
+  @media (max-width: 960px) {
+    padding: 8px 16px 16px;
+    max-width: unset;
+  }
+}
+
+.showOffersMobileButton {
+  max-width: 96px;
+  margin-bottom: 8px;
+
+  @media (min-width: 961px) {
+    display: none;
+  }
+}
+
+.modal :global {
+  .ant-modal-body {
+    height: 440px;
+  }
+
+  .ant-modal-content {
+    padding: 0;
+  }
+}

--- a/src/pages/tokenLending/LendTokenPage/PlaceTokenOffers/components/ExpandedCardContent/ExpandedCardContent.tsx
+++ b/src/pages/tokenLending/LendTokenPage/PlaceTokenOffers/components/ExpandedCardContent/ExpandedCardContent.tsx
@@ -2,8 +2,7 @@ import { FC } from 'react'
 
 import { Button } from '@banx/components/Buttons'
 import { LendTokenActivityTable } from '@banx/components/CommonTables'
-import PlaceTokenOfferSection from '@banx/components/PlaceTokenOfferSection'
-import OrderBook from '@banx/components/PlaceTokenOfferSection/components/OrderBook'
+import PlaceTokenOfferSection, { OrderBook } from '@banx/components/PlaceTokenOfferSection'
 import { Tabs, useTabs } from '@banx/components/Tabs'
 import { Modal } from '@banx/components/modals/BaseModal'
 

--- a/src/pages/tokenLending/LendTokenPage/PlaceTokenOffers/components/ExpandedCardContent/ExpandedCardContent.tsx
+++ b/src/pages/tokenLending/LendTokenPage/PlaceTokenOffers/components/ExpandedCardContent/ExpandedCardContent.tsx
@@ -1,10 +1,49 @@
 import { FC } from 'react'
 
+import { Button } from '@banx/components/Buttons'
 import { LendTokenActivityTable } from '@banx/components/CommonTables'
 import PlaceTokenOfferSection from '@banx/components/PlaceTokenOfferSection'
+import OrderBook from '@banx/components/PlaceTokenOfferSection/components/OrderBook'
 import { Tabs, useTabs } from '@banx/components/Tabs'
+import { Modal } from '@banx/components/modals/BaseModal'
 
-const ExpandedCardContent: FC<{ marketPubkey: string }> = ({ marketPubkey }) => {
+import { TokenMarketPreview } from '@banx/api/tokens'
+import { useModal } from '@banx/store/common'
+
+import styles from './ExpandedCardContent.module.less'
+
+const ExpandedCardContent: FC<{ market: TokenMarketPreview }> = ({ market }) => {
+  const { open: openModal } = useModal()
+
+  const showModal = () => {
+    openModal(OffersModal, { market })
+  }
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.placeOfferContainer}>
+        <Button
+          className={styles.showOffersMobileButton}
+          onClick={showModal}
+          type="circle"
+          variant="tertiary"
+        >
+          See offers
+        </Button>
+
+        <PlaceTokenOfferSection marketPubkey={market.marketPubkey} />
+      </div>
+
+      <div className={styles.tabsContent}>
+        <TabsContent market={market} />
+      </div>
+    </div>
+  )
+}
+
+export default ExpandedCardContent
+
+const TabsContent: FC<{ market: TokenMarketPreview }> = ({ market }) => {
   const { value: currentTabValue, ...tabsProps } = useTabs({
     tabs: TABS,
     defaultValue: TabName.OFFERS,
@@ -13,15 +52,23 @@ const ExpandedCardContent: FC<{ marketPubkey: string }> = ({ marketPubkey }) => 
   return (
     <>
       <Tabs value={currentTabValue} {...tabsProps} />
-      {currentTabValue === TabName.OFFERS && <PlaceTokenOfferSection marketPubkey={marketPubkey} />}
+      {currentTabValue === TabName.OFFERS && <OrderBook market={market} />}
       {currentTabValue === TabName.ACTIVITY && (
-        <LendTokenActivityTable marketPubkey={marketPubkey} />
+        <LendTokenActivityTable marketPubkey={market.marketPubkey} />
       )}
     </>
   )
 }
 
-export default ExpandedCardContent
+const OffersModal: FC<{ market: TokenMarketPreview }> = ({ market }) => {
+  const { close } = useModal()
+
+  return (
+    <Modal className={styles.modal} open onCancel={close}>
+      <TabsContent market={market} />
+    </Modal>
+  )
+}
 
 export enum TabName {
   OFFERS = 'offers',

--- a/src/pages/tokenLending/LendTokenPage/PlaceTokenOffers/components/FilterSection/FilterSection.module.less
+++ b/src/pages/tokenLending/LendTokenPage/PlaceTokenOffers/components/FilterSection/FilterSection.module.less
@@ -36,7 +36,7 @@
 
   display: flex;
   align-items: center;
-  padding: 2px;
+  padding: 4px;
   height: 32px;
 
   user-select: none;

--- a/src/pages/tokenLending/LendTokenPage/PlaceTokenOffers/components/FilterSection/FilterSection.module.less
+++ b/src/pages/tokenLending/LendTokenPage/PlaceTokenOffers/components/FilterSection/FilterSection.module.less
@@ -30,7 +30,8 @@
 
 // * CategoryFilter * //
 .categories {
-  background: var(--bg-tertiary);
+  background: var(--bg-primary);
+  border: var(--border-less-primary);
   border-radius: 100px;
   cursor: pointer;
 
@@ -61,11 +62,8 @@
   width: 100%;
 
   &.active {
-    background: var(--bg-primary);
-
-    span {
-      color: var(--content-primary);
-    }
+    background: var(--action-primary);
+    color: var(--content-primary);
   }
 
   @media screen and (max-width: 1080px) {

--- a/src/pages/tokenLending/LendTokenPage/PlaceTokenOffers/components/LendTokenCard/LendTokenCard.module.less
+++ b/src/pages/tokenLending/LendTokenPage/PlaceTokenOffers/components/LendTokenCard/LendTokenCard.module.less
@@ -18,19 +18,17 @@
   padding: 6px 24px;
   width: 100%;
 
-  &.opened {
-    border-bottom: var(--border-less-primary);
-
-    @media (max-width: 640px) {
-      padding-bottom: 0;
-    }
-  }
-
   @media (max-width: 960px) {
     flex-direction: column;
     align-items: flex-start;
     padding: 8px 16px;
     gap: 16px;
+  }
+
+  @media (max-width: 640px) {
+    &.opened {
+      padding-bottom: 0;
+    }
   }
 }
 

--- a/src/pages/tokenLending/LendTokenPage/PlaceTokenOffers/components/LendTokenCard/LendTokenCard.tsx
+++ b/src/pages/tokenLending/LendTokenPage/PlaceTokenOffers/components/LendTokenCard/LendTokenCard.tsx
@@ -37,7 +37,7 @@ const LendTokenCard: FC<LendTokenCardProps> = ({ market, onClick, isOpen }) => {
           </Button>
         </div>
       </div>
-      {isOpen && <ExpandedCardContent marketPubkey={market.marketPubkey} />}
+      {isOpen && <ExpandedCardContent market={market} />}
     </div>
   )
 }

--- a/src/pages/tokenLending/LoansTokenPage/LoansTokenActiveTable/LoansTokenActiveTable.module.less
+++ b/src/pages/tokenLending/LoansTokenPage/LoansTokenActiveTable/LoansTokenActiveTable.module.less
@@ -43,6 +43,10 @@
   justify-content: flex-end;
   gap: 8px;
   width: 100%;
+
+  button {
+    width: 100%;
+  }
 }
 
 .headerTitleRow {

--- a/src/pages/tokenLending/LoansTokenPage/LoansTokenActiveTable/TableCells/RefinanceTokenModal/OrderBook/cells.tsx
+++ b/src/pages/tokenLending/LoansTokenPage/LoansTokenActiveTable/TableCells/RefinanceTokenModal/OrderBook/cells.tsx
@@ -5,10 +5,7 @@ import { BN } from 'fbonds-core'
 import { BondOfferV3, LendingTokenType } from 'fbonds-core/lib/fbond-protocol/types'
 
 import { Button } from '@banx/components/Buttons'
-import {
-  calculateLtvPercent,
-  formatLeadingZeros,
-} from '@banx/components/PlaceTokenOfferSection/helpers'
+import { calculateLtvPercent, formatLeadingZeros } from '@banx/components/PlaceTokenOfferSection'
 import {
   DisplayValue,
   createDisplayValueJSX,

--- a/src/pages/tokenLending/LoansTokenPage/LoansTokenActiveTable/TableCells/cells.tsx
+++ b/src/pages/tokenLending/LoansTokenPage/LoansTokenActiveTable/TableCells/cells.tsx
@@ -175,7 +175,6 @@ export const ActionsCell: FC<ActionsCellProps> = ({ loan, isCardView, disableAct
   return (
     <div className={styles.actionsButtons}>
       <Button
-        className={styles.refinanceButton}
         size={buttonSize}
         variant="secondary"
         onClick={(event) => {
@@ -186,7 +185,6 @@ export const ActionsCell: FC<ActionsCellProps> = ({ loan, isCardView, disableAct
         {isLoanTerminating ? 'Extend' : 'Reborrow'}
       </Button>
       <Button
-        className={styles.repayButton}
         size={buttonSize}
         disabled={disableActions}
         onClick={(event) => {

--- a/src/pages/tokenLending/LoansTokenPage/LoansTokenActiveTable/hooks/useLoansTokenActiveTable.ts
+++ b/src/pages/tokenLending/LoansTokenPage/LoansTokenActiveTable/hooks/useLoansTokenActiveTable.ts
@@ -7,6 +7,7 @@ import { PATHS } from '@banx/router'
 import { createPathWithModeParams } from '@banx/store'
 import { ModeType } from '@banx/store/common'
 import { useNftTokenType } from '@banx/store/nft'
+import { getTokenTicker } from '@banx/utils'
 
 import { useFilterLoans } from './useFilterLoans'
 import { useSortedLoans } from './useSortedLoans'
@@ -52,8 +53,12 @@ export const useLoansTokenActiveTable = (props: {
     navigate(createPathWithModeParams(PATHS.BORROW_TOKEN, ModeType.Token, tokenType))
   }
 
+  const tokenTicker = getTokenTicker(tokenType)
+
   const emptyListParams = {
-    message: connected ? createConnectedMessage(tokenType) : createNotConnectedMessage(tokenType),
+    message: connected
+      ? createConnectedMessage(tokenTicker)
+      : createNotConnectedMessage(tokenTicker),
     buttonProps: connected ? { text: 'Borrow', onClick: goToBorrowPage } : undefined,
   }
 

--- a/src/pages/tokenLending/OffersTokenPage/components/ActiveLoansTable/Summary/Summary.module.less
+++ b/src/pages/tokenLending/OffersTokenPage/components/ActiveLoansTable/Summary/Summary.module.less
@@ -51,11 +51,11 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 180px;
+  gap: 124px;
   width: 100%;
 
   @media (max-width: 1240px) {
-    gap: 16px;
+    gap: 8px;
   }
 
   & > div {
@@ -65,7 +65,7 @@
     width: 100%;
 
     @media (max-width: 1240px) {
-      min-width: 104px;
+      white-space: nowrap;
     }
 
     @media (max-width: 960px) {
@@ -78,6 +78,10 @@
   @media (min-width: 1241px) {
     display: none;
   }
+}
+
+.aprValueStat {
+  color: var(--additional-green-primary-deep);
 }
 
 .terminateControls {

--- a/src/pages/tokenLending/OffersTokenPage/components/ActiveLoansTable/columns.tsx
+++ b/src/pages/tokenLending/OffersTokenPage/components/ActiveLoansTable/columns.tsx
@@ -95,7 +95,7 @@ export const getTableColumns = ({
       title: (
         <HeaderCell
           label="Repaid"
-          tooltipText="Repayments returned to pending offer if open, or wallet if closed"
+          tooltipText="Repayments returned to the vault and can be claimed from the offers tab or profile modal"
         />
       ),
       render: (loan) => (

--- a/src/pages/tokenLending/OffersTokenPage/components/ExpandedCardContent/ExpandedCardContent.module.less
+++ b/src/pages/tokenLending/OffersTokenPage/components/ExpandedCardContent/ExpandedCardContent.module.less
@@ -1,0 +1,62 @@
+.container {
+  cursor: default;
+  display: flex;
+  overflow: hidden;
+  height: 318px;
+  width: 100%;
+
+  @media (max-width: 960px) {
+    height: 346px;
+  }
+
+  @media (max-width: 640px) {
+    height: 330px;
+  }
+}
+
+.tabsContent {
+  border: var(--border-less-primary);
+  border-right: 0;
+  border-bottom: 0;
+  width: 100%;
+
+  @media (max-width: 960px) {
+    display: none;
+  }
+}
+
+.placeOfferContainer {
+  cursor: default;
+
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 12px 24px 24px;
+
+  max-width: 432px;
+  width: 100%;
+
+  @media (max-width: 960px) {
+    padding: 8px 16px 16px;
+    max-width: unset;
+  }
+}
+
+.showOffersMobileButton {
+  max-width: 96px;
+  margin-bottom: 8px;
+
+  @media (min-width: 961px) {
+    display: none;
+  }
+}
+
+.modal :global {
+  .ant-modal-body {
+    height: 440px;
+  }
+
+  .ant-modal-content {
+    padding: 0;
+  }
+}

--- a/src/pages/tokenLending/OffersTokenPage/components/ExpandedCardContent/ExpandedCardContent.tsx
+++ b/src/pages/tokenLending/OffersTokenPage/components/ExpandedCardContent/ExpandedCardContent.tsx
@@ -2,8 +2,7 @@ import { FC } from 'react'
 
 import { Button } from '@banx/components/Buttons'
 import { LendTokenActivityTable } from '@banx/components/CommonTables'
-import PlaceTokenOfferSection from '@banx/components/PlaceTokenOfferSection'
-import OrderBook from '@banx/components/PlaceTokenOfferSection/components/OrderBook'
+import PlaceTokenOfferSection, { OrderBook } from '@banx/components/PlaceTokenOfferSection'
 import { Tabs, useTabs } from '@banx/components/Tabs'
 import { Modal } from '@banx/components/modals/BaseModal'
 

--- a/src/pages/tokenLending/OffersTokenPage/components/OfferTokenCard/OfferTokenCard.module.less
+++ b/src/pages/tokenLending/OffersTokenPage/components/OfferTokenCard/OfferTokenCard.module.less
@@ -60,7 +60,7 @@
 .mainInfoContainer {
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: 12px;
   min-width: 124px;
 
   @media (max-width: 640px) {

--- a/src/pages/tokenLending/OffersTokenPage/components/OfferTokenCard/OfferTokenCard.module.less
+++ b/src/pages/tokenLending/OffersTokenPage/components/OfferTokenCard/OfferTokenCard.module.less
@@ -15,7 +15,7 @@
   justify-content: space-between;
   align-items: center;
   position: relative;
-  padding: 12px 24px;
+  padding: 6px 24px;
   width: 100%;
 
   @media (max-width: 960px) {
@@ -82,6 +82,7 @@
 // * MarketAdditionalInfo * //
 .additionalInfoStats {
   display: flex;
+  align-items: center;
   justify-content: flex-end;
   gap: 16px;
   white-space: nowrap;
@@ -89,6 +90,7 @@
 
   @media (max-width: 960px) {
     display: grid;
+    align-items: flex-start;
     grid-template-columns: repeat(4, 1fr);
     grid-template-rows: repeat(2, auto);
     gap: 8px;
@@ -97,6 +99,7 @@
 
 .additionalInfoStat {
   align-items: flex-end;
+  gap: 2px;
   max-width: 180px;
   width: 100%;
 

--- a/src/pages/tokenLending/OffersTokenPage/components/OfferTokenCard/OfferTokenCard.module.less
+++ b/src/pages/tokenLending/OffersTokenPage/components/OfferTokenCard/OfferTokenCard.module.less
@@ -18,14 +18,6 @@
   padding: 12px 24px;
   width: 100%;
 
-  &.opened {
-    border-bottom: var(--border-less-primary);
-
-    @media (max-width: 640px) {
-      padding-bottom: 0;
-    }
-  }
-
   @media (max-width: 960px) {
     flex-direction: column;
     align-items: flex-start;
@@ -35,6 +27,10 @@
 
   @media (max-width: 640px) {
     padding: 8px 16px;
+
+    &.opened {
+      padding-bottom: 0;
+    }
   }
 }
 

--- a/src/pages/tokenLending/OffersTokenPage/components/OfferTokenCard/OfferTokenCard.tsx
+++ b/src/pages/tokenLending/OffersTokenPage/components/OfferTokenCard/OfferTokenCard.tsx
@@ -54,7 +54,7 @@ const OfferTokenCard: FC<OfferTokenCardProps> = ({ offerPreview, isOpen, onToggl
       </div>
       {isOpen && (
         <ExpandedCardContent
-          marketPubkey={offerPreview.tokenMarketPreview.marketPubkey}
+          market={offerPreview.tokenMarketPreview}
           offerPubkey={offerPreview.publicKey}
         />
       )}

--- a/src/pages/tokenLending/OffersTokenPage/components/OfferTokenCard/OfferTokenCard.tsx
+++ b/src/pages/tokenLending/OffersTokenPage/components/OfferTokenCard/OfferTokenCard.tsx
@@ -3,7 +3,7 @@ import { FC } from 'react'
 import classNames from 'classnames'
 
 import { Button } from '@banx/components/Buttons'
-import { calculateLtvPercent } from '@banx/components/PlaceTokenOfferSection/helpers'
+import { calculateLtvPercent } from '@banx/components/PlaceTokenOfferSection'
 import { StatInfo } from '@banx/components/StatInfo'
 import { DisplayValue, createPercentValueJSX } from '@banx/components/TableComponents'
 import Tooltip from '@banx/components/Tooltip'

--- a/src/pages/tokenLending/OffersTokenPage/components/TokensListHeader/TokensListHeader.tsx
+++ b/src/pages/tokenLending/OffersTokenPage/components/TokensListHeader/TokensListHeader.tsx
@@ -27,7 +27,7 @@ const TokensListHeader = () => {
           className={styles.additionalStat}
           tooltipText="Annual interest rate. Depends on the loan-to-value (LTV) offered and market capitalization"
         />
-        <Stat label="Status" className={styles.additionalStat} tooltipText="Status" />
+        <Stat label="Status" className={styles.additionalStat} />
       </div>
     </div>
   )

--- a/src/utils/tokens/constants.tsx
+++ b/src/utils/tokens/constants.tsx
@@ -26,6 +26,12 @@ export const TOKEN_UNIT = {
   [LendingTokenType.Usdc]: TokenUnit.Usdc,
 }
 
+export const TOKEN_TICKER = {
+  [LendingTokenType.NativeSol]: 'SOL',
+  [LendingTokenType.BanxSol]: 'SOL',
+  [LendingTokenType.Usdc]: 'USDC',
+}
+
 export const TOKEN_DECIMALS = {
   [LendingTokenType.NativeSol]: 1e9,
   [LendingTokenType.BanxSol]: 1e9,

--- a/src/utils/tokens/helpers.ts
+++ b/src/utils/tokens/helpers.ts
@@ -9,6 +9,7 @@ import {
   MIN_COLLATERAL_VALUE_TO_DISPLAY,
   MIN_VALUE_TO_DISPLAY,
   TOKEN_DECIMALS,
+  TOKEN_TICKER,
   TOKEN_UNIT,
   TokenUnit,
 } from './constants'
@@ -59,6 +60,10 @@ export const getTokenDecimals = (tokenType: LendingTokenType): number => {
 
 export const getTokenUnit = (tokenType: LendingTokenType): TokenUnit => {
   return TOKEN_UNIT[tokenType]
+}
+
+export const getTokenTicker = (tokenType: LendingTokenType): string => {
+  return TOKEN_TICKER[tokenType]
 }
 
 export const isSolTokenType = (tokenType: LendingTokenType): boolean =>


### PR DESCRIPTION
## Description


### Common:
-  Restyle EmptyList component
-  Update "Repaid" tooltip text (My offers => Active)
- Restyle tabs component, add highlight gradient background for active tab
- Restyle ModeSwitcher, TokenSwitcher
- Reduce items in SearchSelect

### Token lending:

Borrow page:
- Replace icon to ticker, remove unnecessary space in text (Warning Modal)
- Sorting collaterals list by value in usd 

Lend page:
- Restyle LendCard
- Reduce size of collateral icon in activity table  
- Set default apr as 30 percent
- Restyle categories filter 
- Rename "Max Offer" to "Offer"

Offers page:
- Restyle OfferCard 
- Add ltv percent to "My offer" column 
- Add tooltip text for each icon in status column
- Add weighted apr, recalculate avg ltv as weighted ltv

My loans:
- Make reborrow and extend buttons the same size
- Fix wrong text in empty list with banxSol

## Issue link

https://linear.app/banx-gg/issue/BAN-2619/fe-banx-token-lending-bugs

## Vercel preview

<!-- Bugfix template -->

https://banx-ui-git-bugfix-ban-2619-frakt.vercel.app/
