### PR TITLE
BAN-2699: Rename tabs on token on My offers page to Offers, Loans, History

### DIFF
--- a/src/pages/nftLending/OffersPage/OffersPage.tsx
+++ b/src/pages/nftLending/OffersPage/OffersPage.tsx
@@ -10,34 +10,34 @@ import styles from './OffersPage.module.less'
 export const OffersPage = () => {
   const { value: currentTabValue, ...tabsProps } = useTabs({
     tabs: OFFERS_TABS,
-    defaultValue: OFFERS_TABS[0].value,
+    defaultValue: OffersTabName.OFFERS,
   })
 
   return (
     <div className={styles.pageWrapper}>
       <OffersHeader />
       <Tabs value={currentTabValue} {...tabsProps} />
-      {currentTabValue === OffersTabName.PENDING && <OffersTabContent />}
-      {currentTabValue === OffersTabName.ACTIVE && <ActiveTabContent />}
+      {currentTabValue === OffersTabName.OFFERS && <OffersTabContent />}
+      {currentTabValue === OffersTabName.LOANS && <ActiveTabContent />}
       {currentTabValue === OffersTabName.HISTORY && <HistoryOffersTable />}
     </div>
   )
 }
 
 enum OffersTabName {
-  PENDING = 'pending',
-  ACTIVE = 'active',
+  OFFERS = 'offers',
+  LOANS = 'loans',
   HISTORY = 'history',
 }
 
 const OFFERS_TABS: Tab[] = [
   {
-    label: 'Pending',
-    value: OffersTabName.PENDING,
+    label: 'Offers',
+    value: OffersTabName.OFFERS,
   },
   {
-    label: 'Active',
-    value: OffersTabName.ACTIVE,
+    label: 'Loans',
+    value: OffersTabName.LOANS,
   },
   {
     label: 'History',


### PR DESCRIPTION
## Issue link

https://linear.app/banx-gg/issue/BAN-2699/fe-banx-rename-tabs-on-token-on-my-offers-page-to-offers-loans-history

## Vercel preview

<!-- Feature template -->

https://banx-ui-git-feature-ban-2699-frakt.vercel.app/